### PR TITLE
Enable execution environment support

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,5 @@
+---
+- project:
+    templates:
+      - network-ee-container-image-jobs
+      - network-ee-tests

--- a/changelogs/fragments/upcap_ansible.yaml
+++ b/changelogs/fragments/upcap_ansible.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - uncap ansible in meta/runtime.yaml
+  - move python requirements to requirements.txt for execution environments

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.10,<2.11'
+requires_ansible: '>=2.9.10'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+jsonschema
+textfsm
+ttp
+xmltodict

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,14 +4,3 @@ flake8
 mock ; python_version < '3.5'
 pytest-xdist
 yamllint
-
-# The follow are 3rd party libs for validate
-jsonschema
-# /valiate
-
-# The follow are 3rd party libs for cli_parse
-textfsm
-ttp
-xmltodict
-# /cli_parse
-


### PR DESCRIPTION
This starts to run sanity / unit tests via execution environments.

Depends-On: https://github.com/ansible/network-ee/pull/33
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/751
Signed-off-by: Paul Belanger <pabelanger@redhat.com>