### PR TITLE
Fix cli_parse module to support netcommon sub-plugins

### DIFF
--- a/changelogs/cli_parse_fix.yaml
+++ b/changelogs/cli_parse_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix ansible.utils.cli_parse action plugin to support old cli_parse sub-plugin
+    structure in ansible.netcommon collection.

--- a/changelogs/fragments/cli_parse_fix.yaml
+++ b/changelogs/fragments/cli_parse_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix ansible.utils.cli_parse action plugin to support old cli_parse sub-plugin
+    structure in ansible.netcommon collection.


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Try to load the cli_parse sub-plugins in netcommon collection from
   old structure path is not present under `sub_plugins` folder to
   support the netcommon 1.x.y collection releases
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cli_parse

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
