### PR TITLE
Fix cli_parse template_path read error

### DIFF
--- a/changelogs/fragments/cli_parse_errors_return.yaml
+++ b/changelogs/fragments/cli_parse_errors_return.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix cli_parse template_path read error (https://github.com/ansible-collections/ansible.utils/pull/51).

--- a/plugins/sub_plugins/cli_parser/textfsm_parser.py
+++ b/plugins/sub_plugins/cli_parser/textfsm_parser.py
@@ -94,14 +94,14 @@ class CliParser(CliParserBase):
         template_path = self._task_args.get("parser").get("template_path")
         if template_path and not os.path.isfile(template_path):
             return {
-                "error": "error while reading template_path file {file}".format(
+                "errors": "error while reading template_path file {file}".format(
                     file=template_path
                 )
             }
         try:
             template = open(self._task_args.get("parser").get("template_path"))
         except IOError as exc:
-            return {"error": to_native(exc)}
+            return {"errors": to_native(exc)}
 
         re_table = textfsm.TextFSM(template)
         fsm_results = re_table.ParseText(cli_output)

--- a/plugins/sub_plugins/cli_parser/ttp_parser.py
+++ b/plugins/sub_plugins/cli_parser/ttp_parser.py
@@ -99,7 +99,7 @@ class CliParser(CliParserBase):
         )
         if template_path and not os.path.isfile(template_path):
             return {
-                "error": "error while reading template_path file {file}".format(
+                "errors": "error while reading template_path file {file}".format(
                     file=template_path
                 )
             }

--- a/tests/unit/plugins/sub_plugins/cli_parsers/test_textfsm_parser.py
+++ b/tests/unit/plugins/sub_plugins/cli_parsers/test_textfsm_parser.py
@@ -63,9 +63,9 @@ class TestTextfsmParser(unittest.TestCase):
         }
         parser = CliParser(task_args=task_args, task_vars=[], debug=False)
         result = parser.parse()
-        error = {
-            "error": "error while reading template_path file {0}".format(
+        errors = {
+            "errors": "error while reading template_path file {0}".format(
                 fake_path
             )
         }
-        self.assertEqual(result, error)
+        self.assertEqual(result, errors)

--- a/tests/unit/plugins/sub_plugins/cli_parsers/test_ttp_parser.py
+++ b/tests/unit/plugins/sub_plugins/cli_parsers/test_ttp_parser.py
@@ -63,9 +63,9 @@ class TestTextfsmParser(unittest.TestCase):
         }
         parser = CliParser(task_args=task_args, task_vars=[], debug=False)
         result = parser.parse()
-        error = {
-            "error": "error while reading template_path file {0}".format(
+        errors = {
+            "errors": "error while reading template_path file {0}".format(
                 fake_path
             )
         }
-        self.assertEqual(result, error)
+        self.assertEqual(result, errors)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  If sub-plugins (ttp, textfsm) fails to pass template file path
   return the error as value of `errors` key instead on `error`
   as the `cli_parse` action plugin expects `errors` key

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ttp_parser
textfsm_parser
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
