### PR TITLE
Fix index_of integration test

### DIFF
--- a/changelogs/fragments/fix_tests.yaml
+++ b/changelogs/fragments/fix_tests.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fix index_of tests.

--- a/tests/integration/targets/index_of/tasks/include/argspec.yaml
+++ b/tests/integration/targets/index_of/tasks/include/argspec.yaml
@@ -13,7 +13,7 @@
 
 - name: Check argspec validation with filter (not a list)
   ansible.builtin.set_fact:
-    _result: "{{ complex|ansible.utils.index_of() }}"
+    _result: "{{ complex|ansible.utils.index_of('eq', 2) }}"
   ignore_errors: true
   register: result
 
@@ -35,7 +35,7 @@
 
 - name: Check argspec validation with lookup (not a list)
   ansible.builtin.set_fact:
-    _result: "{{ lookup('ansible.utils.index_of', complex) }}"
+    _result: "{{ lookup('ansible.utils.index_of', complex, 'eq', 2) }}"
   ignore_errors: true
   register: result
 

--- a/tests/unit/module_utils/test_argspec_validate.py
+++ b/tests/unit/module_utils/test_argspec_validate.py
@@ -129,9 +129,6 @@ class TestSortList(unittest.TestCase):
             other_args={"bypass_checks": True},
         )
         valid, errors, _updated_data = aav.validate()
-        print(valid)
-        print(errors)
-        print(_updated_data)
         self.assertTrue(valid)
         self.assertIsNone(errors)
 

--- a/tests/unit/module_utils/test_argspec_validate.py
+++ b/tests/unit/module_utils/test_argspec_validate.py
@@ -120,7 +120,7 @@ class TestSortList(unittest.TestCase):
         )
 
     def test_other_args(self):
-        data = {}
+        data = {"param_str": "string"}
         aav = AnsibleArgSpecValidator(
             data=data,
             schema=DOCUMENTATION,
@@ -129,6 +129,9 @@ class TestSortList(unittest.TestCase):
             other_args={"bypass_checks": True},
         )
         valid, errors, _updated_data = aav.validate()
+        print(valid)
+        print(errors)
+        print(_updated_data)
         self.assertTrue(valid)
         self.assertIsNone(errors)
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

The changes introduced in https://github.com/ansible/ansible/pull/73703 is causing assertions errors for certain tests in index_of. Essentially, type validation is done after argspec validation it seems.

Steps to reproduce:
- Fetch latest devel and rebase.
- `ansible-test integration --diff --no-temp-workdir --skip-tags False --continue-on-error --python 3.6 index_of -vvvv`
-  It should fail.
- `git checkout 089d0a0508a470799d099d95fc371e66756a00b3`
- Re-run the test.
- It should pass this time.

The test_validate_argspec.py/test_other_args was also failing with `missing required arguments: param_str`.