### PR TITLE
Added 'subnet_of', 'supernet_of', 'unspecified' IP test plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Name | Description
 [ansible.utils.private](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.private_test.rst)|Test if an IP address is private
 [ansible.utils.public](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.public_test.rst)|Test if an IP address is public
 [ansible.utils.reserved](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.reserved_test.rst)|Test for a reserved IP address
+[ansible.utils.subnet_of](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.subnet_of_test.rst)|Test if a network is a subnet of another network
+[ansible.utils.supernet_of](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.supernet_of_test.rst)|Test if a network is a supernet of another network
+[ansible.utils.unspecified](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.unspecified_test.rst)|Test for an unspecified IP address
 [ansible.utils.validate](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.validate_test.rst)|Validate data with provided criteria
 
 <!--end collection content-->

--- a/changelogs/fragments/add_netaddr_test_plugins_7.yml
+++ b/changelogs/fragments/add_netaddr_test_plugins_7.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add subnet_of, supernet_of, unspecified test plugins

--- a/docs/ansible.utils.subnet_of_test.rst
+++ b/docs/ansible.utils.subnet_of_test.rst
@@ -1,0 +1,155 @@
+.. _ansible.utils.subnet_of_test:
+
+
+***********************
+ansible.utils.subnet_of
+***********************
+
+**Test if a network is a subnet of another network**
+
+
+Version added: 2.2.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This plugin checks if the first network is a subnet of the second network amongst the provided network addresses
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                <th>Configuration</th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>network_a</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>A string that represents the first network address</div>
+                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.0/24&#x27;]}</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>network_b</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>A string that represents the second network address</div>
+                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/8&#x27;]}</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Check if 10.1.1.0/24 is a subnet of 10.0.0.0/8
+      ansible.builtin.set_fact:
+        data: "{{ '10.1.1.0/24' is ansible.utils.subnet_of '10.0.0.0/8' }}"
+
+    # TASK [Check if 10.1.1.0/24 is a subnet of 10.0.0.0/8] **************************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+    - name: Check if 192.168.1.0/24 is not a subnet of 10.0.0.0/8
+      ansible.builtin.set_fact:
+        data: "{{ '192.168.1.0/24' is not ansible.utils.subnet_of '10.0.0.0/8' }}"
+
+    # TASK [Check if 192.168.1.0/24 is not a subnet of 10.0.0.0/8] *******************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this test:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                    </div>
+                </td>
+                <td></td>
+                <td>
+                            <div>If jinja test satisfies plugin expression <code>true</code></div>
+                            <div>If jinja test does not satisfy plugin expression <code>false</code></div>
+                    <br/>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Priyam Sahoo (@priyamsahoo)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.utils.supernet_of_test.rst
+++ b/docs/ansible.utils.supernet_of_test.rst
@@ -1,0 +1,155 @@
+.. _ansible.utils.supernet_of_test:
+
+
+*************************
+ansible.utils.supernet_of
+*************************
+
+**Test if a network is a supernet of another network**
+
+
+Version added: 2.2.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This plugin checks if the first network is a supernet of the second network amongst the provided network addresses
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                <th>Configuration</th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>network_a</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>A string that represents the first network address</div>
+                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.0/24&#x27;]}</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>network_b</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>A string that represents the second network address</div>
+                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/8&#x27;]}</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Check if 10.0.0.0/8 is a supernet of 10.1.1.0/24
+      ansible.builtin.set_fact:
+        data: "{{ '10.0.0.0/8' is ansible.utils.supernet_of '10.1.1.0/24' }}"
+
+    # TASK [Check if 10.0.0.0/8 is a supernet of 10.1.1.0/24] ************************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+    - name: Check if 10.0.0.0/8 is not a supernet of 192.168.1.0/24
+      ansible.builtin.set_fact:
+        data: "{{ '10.0.0.0/8' is not ansible.utils.supernet_of '192.168.1.0/24' }}"
+
+    # TASK [Check if 10.0.0.0/8 is not a supernet of 192.168.1.0/24] *****************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this test:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                    </div>
+                </td>
+                <td></td>
+                <td>
+                            <div>If jinja test satisfies plugin expression <code>true</code></div>
+                            <div>If jinja test does not satisfy plugin expression <code>false</code></div>
+                    <br/>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Priyam Sahoo (@priyamsahoo)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.utils.unspecified_test.rst
+++ b/docs/ansible.utils.unspecified_test.rst
@@ -1,0 +1,162 @@
+.. _ansible.utils.unspecified_test:
+
+
+*************************
+ansible.utils.unspecified
+*************************
+
+**Test for an unspecified IP address**
+
+
+Version added: 2.2.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This plugin checks if the provided value is an unspecified IP address
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                <th>Configuration</th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>ip</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>A string that represents the value against which the test is going to be performed</div>
+                        <div>{&#x27;For example&#x27;: [&#x27;0.0.0.0&#x27;, &#x27;0:0:0:0:0:0:0:0&#x27;, &#x27;::&#x27;, &#x27;::1&#x27;]}</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    #### Simple examples
+
+    - name: Check if 0.0.0.0 is an unspecified IP address
+      ansible.builtin.set_fact:
+        data: "{{ '0.0.0.0' is ansible.utils.unspecified }}"
+
+    # TASK [Check if 0.0.0.0 is an unspecified IP address] ***************************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+    - name: Check if 0:0:0:0:0:0:0:0 is an unspecified IP address
+      ansible.builtin.set_fact:
+        data: "{{ '0:0:0:0:0:0:0:0' is ansible.utils.unspecified }}"
+
+    # TASK [Check if 0:0:0:0:0:0:0:0 is an unspecified IP address] *******************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+    - name: Check if "::" is an unspecified IP address
+      ansible.builtin.set_fact:
+        data: "{{ '::' is ansible.utils.unspecified }}"
+
+    # TASK [Check if "::" is an unspecified IP address] ******************************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+    - name: Check if ::1 is not an unspecified IP address
+      ansible.builtin.set_fact:
+        data: "{{ '::1' is not ansible.utils.unspecified }}"
+
+    # TASK [Check if ::1 is not an unspecified IP address] ***************************
+    # ok: [localhost] => {
+    #     "ansible_facts": {
+    #         "data": true
+    #     },
+    #     "changed": false
+    # }
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this test:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">-</span>
+                    </div>
+                </td>
+                <td></td>
+                <td>
+                            <div>If jinja test satisfies plugin expression <code>true</code></div>
+                            <div>If jinja test does not satisfy plugin expression <code>false</code></div>
+                    <br/>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Priyam Sahoo (@priyamsahoo)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/plugins/test/subnet_of.py
+++ b/plugins/test/subnet_of.py
@@ -9,7 +9,10 @@ Test plugin file for netaddr tests: subnet_of
 
 from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network, _need_ipaddress, _is_subnet_of, _validate_args
+    ip_network,
+    _need_ipaddress,
+    _is_subnet_of,
+    _validate_args,
 )
 
 __metaclass__ = type
@@ -74,6 +77,7 @@ RETURN = """
       - If jinja test does not satisfy plugin expression C(false)
 """
 
+
 @_need_ipaddress
 def _subnet_of(network_a, network_b):
     """ Test if a network is a subnet of another network """
@@ -85,6 +89,7 @@ def _subnet_of(network_a, network_b):
         return _is_subnet_of(ip_network(network_a), ip_network(network_b))
     except Exception:
         return False
+
 
 class TestModule(object):
     """ network jinja test """

--- a/plugins/test/subnet_of.py
+++ b/plugins/test/subnet_of.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Test plugin file for netaddr tests: subnet_of
+"""
+
+from __future__ import absolute_import, division, print_function
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
+    ip_network, _need_ipaddress, _is_subnet_of, _validate_args
+)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: subnet_of
+    author: Priyam Sahoo (@priyamsahoo)
+    version_added: "2.2.0"
+    short_description: Test if a network is a subnet of another network
+    description:
+        - This plugin checks if the first network is a subnet of the second network amongst the provided network addresses
+    options:
+        network_a:
+            description:
+            - A string that represents the first network address
+            - For example:
+                - "10.1.1.0/24"
+            type: str
+            required: True
+        network_b:
+            description:
+            - A string that represents the second network address
+            - For example:
+                - "10.0.0.0/8"
+            type: str
+            required: True
+    notes:
+"""
+
+EXAMPLES = r"""
+
+- name: Check if 10.1.1.0/24 is a subnet of 10.0.0.0/8
+  ansible.builtin.set_fact:
+    data: "{{ '10.1.1.0/24' is ansible.utils.subnet_of '10.0.0.0/8' }}"
+
+# TASK [Check if 10.1.1.0/24 is a subnet of 10.0.0.0/8] **************************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+- name: Check if 192.168.1.0/24 is not a subnet of 10.0.0.0/8
+  ansible.builtin.set_fact:
+    data: "{{ '192.168.1.0/24' is not ansible.utils.subnet_of '10.0.0.0/8' }}"
+
+# TASK [Check if 192.168.1.0/24 is not a subnet of 10.0.0.0/8] *******************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+"""
+
+RETURN = """
+  data:
+    description:
+      - If jinja test satisfies plugin expression C(true)
+      - If jinja test does not satisfy plugin expression C(false)
+"""
+
+@_need_ipaddress
+def _subnet_of(network_a, network_b):
+    """ Test if a network is a subnet of another network """
+
+    params = {"network_a": network_a, "network_b": network_b}
+    _validate_args("subnet_of", DOCUMENTATION, params)
+
+    try:
+        return _is_subnet_of(ip_network(network_a), ip_network(network_b))
+    except Exception:
+        return False
+
+class TestModule(object):
+    """ network jinja test """
+
+    test_map = {"subnet_of": _subnet_of}
+
+    def tests(self):
+        return self.test_map

--- a/plugins/test/supernet_of.py
+++ b/plugins/test/supernet_of.py
@@ -9,7 +9,10 @@ Test plugin file for netaddr tests: supernet_of
 
 from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network, _need_ipaddress, _is_subnet_of, _validate_args
+    ip_network,
+    _need_ipaddress,
+    _is_subnet_of,
+    _validate_args,
 )
 
 __metaclass__ = type
@@ -74,6 +77,7 @@ RETURN = """
       - If jinja test does not satisfy plugin expression C(false)
 """
 
+
 @_need_ipaddress
 def _supernet_of(network_a, network_b):
     """ Test if an network is a supernet of another network """
@@ -85,6 +89,7 @@ def _supernet_of(network_a, network_b):
         return _is_subnet_of(ip_network(network_b), ip_network(network_a))
     except Exception:
         return False
+
 
 class TestModule(object):
     """ network jinja test """

--- a/plugins/test/supernet_of.py
+++ b/plugins/test/supernet_of.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Test plugin file for netaddr tests: supernet_of
+"""
+
+from __future__ import absolute_import, division, print_function
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
+    ip_network, _need_ipaddress, _is_subnet_of, _validate_args
+)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: supernet_of
+    author: Priyam Sahoo (@priyamsahoo)
+    version_added: "2.2.0"
+    short_description: Test if a network is a supernet of another network
+    description:
+        - This plugin checks if the first network is a supernet of the second network amongst the provided network addresses
+    options:
+        network_a:
+            description:
+            - A string that represents the first network address
+            - For example:
+                - "10.1.1.0/24"
+            type: str
+            required: True
+        network_b:
+            description:
+            - A string that represents the second network address
+            - For example:
+                - "10.0.0.0/8"
+            type: str
+            required: True
+    notes:
+"""
+
+EXAMPLES = r"""
+
+- name: Check if 10.0.0.0/8 is a supernet of 10.1.1.0/24
+  ansible.builtin.set_fact:
+    data: "{{ '10.0.0.0/8' is ansible.utils.supernet_of '10.1.1.0/24' }}"
+
+# TASK [Check if 10.0.0.0/8 is a supernet of 10.1.1.0/24] ************************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+- name: Check if 10.0.0.0/8 is not a supernet of 192.168.1.0/24
+  ansible.builtin.set_fact:
+    data: "{{ '10.0.0.0/8' is not ansible.utils.supernet_of '192.168.1.0/24' }}"
+
+# TASK [Check if 10.0.0.0/8 is not a supernet of 192.168.1.0/24] *****************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+"""
+
+RETURN = """
+  data:
+    description:
+      - If jinja test satisfies plugin expression C(true)
+      - If jinja test does not satisfy plugin expression C(false)
+"""
+
+@_need_ipaddress
+def _supernet_of(network_a, network_b):
+    """ Test if an network is a supernet of another network """
+
+    params = {"network_a": network_a, "network_b": network_b}
+    _validate_args("supernet_of", DOCUMENTATION, params)
+
+    try:
+        return _is_subnet_of(ip_network(network_b), ip_network(network_a))
+    except Exception:
+        return False
+
+class TestModule(object):
+    """ network jinja test """
+
+    test_map = {"supernet_of": _supernet_of}
+
+    def tests(self):
+        return self.test_map

--- a/plugins/test/unspecified.py
+++ b/plugins/test/unspecified.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Test plugin file for netaddr tests: unspecified
+"""
+
+from __future__ import absolute_import, division, print_function
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
+    ip_address, _need_ipaddress, _validate_args
+)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: unspecified
+    author: Priyam Sahoo (@priyamsahoo)
+    version_added: "2.2.0"
+    short_description: Test for an unspecified IP address
+    description:
+        - This plugin checks if the provided value is an unspecified IP address
+    options:
+        ip:
+            description:
+            - A string that represents the value against which the test is going to be performed
+            - For example:
+                - "0.0.0.0"
+                - "0:0:0:0:0:0:0:0"
+                - "::"
+                - "::1"
+            type: str
+            required: True
+    notes:
+"""
+
+EXAMPLES = r"""
+
+#### Simple examples
+
+- name: Check if 0.0.0.0 is an unspecified IP address
+  ansible.builtin.set_fact:
+    data: "{{ '0.0.0.0' is ansible.utils.unspecified }}"
+
+# TASK [Check if 0.0.0.0 is an unspecified IP address] ***************************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+- name: Check if 0:0:0:0:0:0:0:0 is an unspecified IP address
+  ansible.builtin.set_fact:
+    data: "{{ '0:0:0:0:0:0:0:0' is ansible.utils.unspecified }}"
+
+# TASK [Check if 0:0:0:0:0:0:0:0 is an unspecified IP address] *******************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+- name: Check if "::" is an unspecified IP address
+  ansible.builtin.set_fact:
+    data: "{{ '::' is ansible.utils.unspecified }}"
+
+# TASK [Check if "::" is an unspecified IP address] ******************************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+- name: Check if ::1 is not an unspecified IP address
+  ansible.builtin.set_fact:
+    data: "{{ '::1' is not ansible.utils.unspecified }}"
+
+# TASK [Check if ::1 is not an unspecified IP address] ***************************
+# ok: [localhost] => {
+#     "ansible_facts": {
+#         "data": true
+#     },
+#     "changed": false
+# }
+
+"""
+
+RETURN = """
+  data:
+    description:
+      - If jinja test satisfies plugin expression C(true)
+      - If jinja test does not satisfy plugin expression C(false)
+"""
+
+@_need_ipaddress
+def _unspecified(ip):
+    """ Test for an unspecified IP address """
+
+    params = {"ip": ip}
+    _validate_args("unspecified", DOCUMENTATION, params)
+
+    try:
+        return ip_address(ip).is_unspecified
+    except Exception:
+        return False
+
+class TestModule(object):
+    """ network jinja test"""
+
+    test_map = {"unspecified": _unspecified}
+
+    def tests(self):
+        return self.test_map

--- a/plugins/test/unspecified.py
+++ b/plugins/test/unspecified.py
@@ -9,7 +9,9 @@ Test plugin file for netaddr tests: unspecified
 
 from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address, _need_ipaddress, _validate_args
+    ip_address,
+    _need_ipaddress,
+    _validate_args,
 )
 
 __metaclass__ = type
@@ -96,6 +98,7 @@ RETURN = """
       - If jinja test does not satisfy plugin expression C(false)
 """
 
+
 @_need_ipaddress
 def _unspecified(ip):
     """ Test for an unspecified IP address """
@@ -107,6 +110,7 @@ def _unspecified(ip):
         return ip_address(ip).is_unspecified
     except Exception:
         return False
+
 
 class TestModule(object):
     """ network jinja test"""

--- a/tests/integration/targets/netaddr_test/tasks/include/subnet_of.yml
+++ b/tests/integration/targets/netaddr_test/tasks/include/subnet_of.yml
@@ -1,0 +1,20 @@
+---
+- name: "subnet_of: Check if 10.1.1.0/24 is a subnet of 10.0.0.0/8"
+  assert:
+    that: "{{ '10.1.1.0/24' is ansible.utils.subnet_of '10.0.0.0/8' }}"
+
+- name: "subnet_of: Test invalidness"
+  ansible.builtin.set_fact:
+    criteria_check1: "{{ '10.0.0.0/8' is ansible.utils.subnet_of '10.1.1.0/24' }}"
+
+- name: "subnet_of: Assert invalidness"
+  assert:
+    that: "{{ criteria_check1 == false }}"
+
+- name: "subnet_of: Test invalidness"
+  ansible.builtin.set_fact:
+    criteria_check2: "{{ '192.168.1.0/24' is ansible.utils.subnet_of '10.0.0.0/8' }}"
+
+- name: "subnet_of: Assert invalidness"
+  assert:
+    that: "{{ criteria_check2 == false }}"

--- a/tests/integration/targets/netaddr_test/tasks/include/supernet_of.yml
+++ b/tests/integration/targets/netaddr_test/tasks/include/supernet_of.yml
@@ -1,0 +1,20 @@
+---
+- name: "supernet_of: Check if 10.0.0.0/8 is a supernet of 10.1.1.0/24"
+  assert:
+    that: "{{ '10.0.0.0/8' is ansible.utils.supernet_of '10.1.1.0/24' }}"
+
+- name: "supernet_of: Test invalidness"
+  ansible.builtin.set_fact:
+    criteria_check1: "{{ '10.1.1.0/24' is ansible.utils.supernet_of '10.0.0.0/8' }}"
+
+- name: "supernet_of: Assert invalidness"
+  assert:
+    that: "{{ criteria_check1 == false }}"
+
+- name: "supernet_of: Test invalidness"
+  ansible.builtin.set_fact:
+    criteria_check2: "{{ '10.0.0.0/8' is ansible.utils.supernet_of '192.168.1.0/24' }}"
+
+- name: "supernet_of: Assert invalidness"
+  assert:
+    that: "{{ criteria_check2 == false }}"

--- a/tests/integration/targets/netaddr_test/tasks/include/unspecified.yml
+++ b/tests/integration/targets/netaddr_test/tasks/include/unspecified.yml
@@ -1,0 +1,28 @@
+---
+- name: "unspecified: Check if 0.0.0.0 is an unspecified IP address"
+  assert:
+    that: "{{ '0.0.0.0' is ansible.utils.unspecified }}"
+
+- name: "unspecified: Check if 0:0:0:0:0:0:0:0 is an unspecified IP address"
+  assert:
+    that: "{{ '0:0:0:0:0:0:0:0' is ansible.utils.unspecified }}"
+
+- name: "unspecified: Check if :: is an unspecified IP address"
+  assert:
+    that: "{{ '::' is ansible.utils.unspecified }}"
+
+- name: "unspecified: Test invalidness"
+  ansible.builtin.set_fact:
+    criteria_check1: "{{ '127.0.0.1' is ansible.utils.unspecified }}"
+
+- name: "unspecified: Assert invalidness"
+  assert:
+    that: "{{ criteria_check1 == false }}"
+
+- name: "unspecified: Test invalidness"
+  ansible.builtin.set_fact:
+    criteria_check2: "{{ '::1' is ansible.utils.unspecified }}"
+
+- name: "unspecified: Assert invalidness"
+  assert:
+    that: "{{ criteria_check2 == false }}"

--- a/tests/unit/plugins/test/test_subnet_of.py
+++ b/tests/unit/plugins/test/test_subnet_of.py
@@ -12,18 +12,12 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import unittest
-from ansible.errors import AnsibleError
-from ansible_collections.ansible.utils.plugins.test.subnet_of import (
-    _subnet_of,
-)
+from ansible_collections.ansible.utils.plugins.test.subnet_of import _subnet_of
 
 
 class TestSubnetOf(unittest.TestCase):
     def setUp(self):
         pass
-
-    def test_invalid_data(self):
-        """Check passing invalid argspec"""
 
     def test_invalid_data(self):
         """Check passing invalid argspec"""

--- a/tests/unit/plugins/test/test_subnet_of.py
+++ b/tests/unit/plugins/test/test_subnet_of.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit test file for netaddr test plugin: subnet_of
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import unittest
+from ansible.errors import AnsibleError
+from ansible_collections.ansible.utils.plugins.test.subnet_of import (
+    _subnet_of,
+)
+
+
+class TestSubnetOf(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_invalid_data(self):
+        """Check passing invalid argspec"""
+
+    def test_invalid_data(self):
+        """Check passing invalid argspec"""
+
+        # missing argument
+        with self.assertRaises(TypeError) as error:
+            _subnet_of()
+        self.assertIn("argument", str(error.exception))
+
+        with self.assertRaises(TypeError) as error:
+            _subnet_of(network_a="10.1.1.0/24")
+        self.assertIn("argument", str(error.exception))
+
+        with self.assertRaises(TypeError) as error:
+            _subnet_of(network_b="10.0.0.0/8")
+        self.assertIn("argument", str(error.exception))
+
+    def test_valid_data(self):
+        """Check passing valid data as per criteria"""
+
+        result = _subnet_of(network_a="10.1.1.0/24", network_b="10.0.0.0/8")
+        self.assertEqual(result, True)
+
+        result = _subnet_of(network_a="10.0.0.0/8", network_b="10.1.1.0/24")
+        self.assertEqual(result, False)
+
+        result = _subnet_of(network_a="192.168.1.0/24", network_b="10.0.0.0/8")
+        self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_supernet_of.py
+++ b/tests/unit/plugins/test/test_supernet_of.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import unittest
-from ansible.errors import AnsibleError
 from ansible_collections.ansible.utils.plugins.test.supernet_of import (
     _supernet_of,
 )
@@ -21,9 +20,6 @@ from ansible_collections.ansible.utils.plugins.test.supernet_of import (
 class TestSupernetOf(unittest.TestCase):
     def setUp(self):
         pass
-
-    def test_invalid_data(self):
-        """Check passing invalid argspec"""
 
     def test_invalid_data(self):
         """Check passing invalid argspec"""
@@ -50,5 +46,7 @@ class TestSupernetOf(unittest.TestCase):
         result = _supernet_of(network_a="10.1.1.0/24", network_b="10.0.0.0/8")
         self.assertEqual(result, False)
 
-        result = _supernet_of(network_a="10.0.0.0/8", network_b="192.168.1.0/24")
+        result = _supernet_of(
+            network_a="10.0.0.0/8", network_b="192.168.1.0/24"
+        )
         self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_supernet_of.py
+++ b/tests/unit/plugins/test/test_supernet_of.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit test file for netaddr test plugin: supernet_of
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import unittest
+from ansible.errors import AnsibleError
+from ansible_collections.ansible.utils.plugins.test.supernet_of import (
+    _supernet_of,
+)
+
+
+class TestSupernetOf(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_invalid_data(self):
+        """Check passing invalid argspec"""
+
+    def test_invalid_data(self):
+        """Check passing invalid argspec"""
+
+        # missing argument
+        with self.assertRaises(TypeError) as error:
+            _supernet_of()
+        self.assertIn("argument", str(error.exception))
+
+        with self.assertRaises(TypeError) as error:
+            _supernet_of(network_a="10.0.0.0/8")
+        self.assertIn("argument", str(error.exception))
+
+        with self.assertRaises(TypeError) as error:
+            _supernet_of(network_b="10.1.1.0/24")
+        self.assertIn("argument", str(error.exception))
+
+    def test_valid_data(self):
+        """Check passing valid data as per criteria"""
+
+        result = _supernet_of(network_a="10.0.0.0/8", network_b="10.1.1.0/24")
+        self.assertEqual(result, True)
+
+        result = _supernet_of(network_a="10.1.1.0/24", network_b="10.0.0.0/8")
+        self.assertEqual(result, False)
+
+        result = _supernet_of(network_b="10.0.0.0/8", network_a="192.168.1.0/24")
+        self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_supernet_of.py
+++ b/tests/unit/plugins/test/test_supernet_of.py
@@ -50,5 +50,5 @@ class TestSupernetOf(unittest.TestCase):
         result = _supernet_of(network_a="10.1.1.0/24", network_b="10.0.0.0/8")
         self.assertEqual(result, False)
 
-        result = _supernet_of(network_b="10.0.0.0/8", network_a="192.168.1.0/24")
+        result = _supernet_of(network_a="10.0.0.0/8", network_b="192.168.1.0/24")
         self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_unspecified.py
+++ b/tests/unit/plugins/test/test_unspecified.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit test file for netaddr test plugin: unspecified
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import unittest
+from ansible_collections.ansible.utils.plugins.test.unspecified import _unspecified
+
+
+class TestUnspecified(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_invalid_data(self):
+        """Check passing invalid argspec"""
+
+        # missing argument
+        with self.assertRaises(TypeError) as error:
+            _unspecified()
+        self.assertIn("argument", str(error.exception))
+
+    def test_valid_data(self):
+        """Check passing valid data as per criteria"""
+
+        result = _unspecified(ip="0.0.0.0")
+        self.assertEqual(result, True)
+
+        result = _unspecified(ip="0:0:0:0:0:0:0:0")
+        self.assertEqual(result, True)
+
+        result = _unspecified(ip="::")
+        self.assertEqual(result, True)
+
+        result = _unspecified(ip="127.0.0.1")
+        self.assertEqual(result, False)
+
+        result = _unspecified(ip="::1")
+        self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_unspecified.py
+++ b/tests/unit/plugins/test/test_unspecified.py
@@ -12,7 +12,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.unspecified import _unspecified
+from ansible_collections.ansible.utils.plugins.test.unspecified import (
+    _unspecified,
+)
 
 
 class TestUnspecified(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds test plugins for subnet, supernet and unspecified IP addresses
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Plugins Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
1. subnet.py
2. supernet.py
3. unspecified.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
