### PR TITLE
Add 'netaddr' To 'requirements.txt' For Unit Tests

### DIFF
--- a/changelogs/fragments/unit_test_container_venv.yaml
+++ b/changelogs/fragments/unit_test_container_venv.yaml
@@ -1,5 +1,5 @@
 ---
-bugfixes:
+trivial:
   - >-
     unit-testing - adds the python netaddr module as a requirement that
     ansible-test will install when operating in container (--docker) or python

--- a/changelogs/fragments/unit_test_container_venv.yaml
+++ b/changelogs/fragments/unit_test_container_venv.yaml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    unit-testing - adds the python netaddr module as a requirement that
+    ansible-test will install when operating in container (--docker) or python
+    virtual environment (--venv) mode.
+    (https://github.com/ansible-collections/ansible.utils/issues/142)

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,5 @@
-unittest2 ; python_version < '2.7'
 jsonschema ; python_version >= '2.7'
-ttp
+netaddr
 textfsm
+ttp
+unittest2 ; python_version < '2.7'


### PR DESCRIPTION
* This enables 'ansible-test --docker' and 'ansible-test --venv' to be able to leverage 'netaddr' and pass tests

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds the 'netaddr' python module to the requirements specific to unit tests. This allows 'ansible-test' to work for '--docker' and '--venv' without manual intervention.

I also re-ordered the current list to be alphabetical.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #142 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Unit tests in ansible.utils for ipsubnet

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
git clone https://github.com/ansible-collections/ansible.utils.git
cd ansible.utils
ansible-galaxy collection build .
ansible-galaxy collection install -p . ansible-utils-\*.tar.gz
ansible-test units --docker base tests/unit/plugins/filter/test_ipsubnet.py --requirements --verbose
```
