### PR TITLE
Exclude for sanity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: Test collection
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test collection
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,27 @@ jobs:
     uses: ansible-network/github_actions/.github/workflows/integration_simple.yml@main
   sanity:
     uses: ansible-network/github_actions/.github/workflows/sanity.yml@main
+    with:
+      matrix_exclude: >-
+        [
+          {
+            "ansible-version": "stable-2.9",
+            "python-version": "3.9"
+          },
+          {
+            "ansible-version": "stable-2.9",
+            "python-version": "3.10"
+          },
+          {
+            "ansible-version": "stable-2.10",
+            "python-version": "3.10"
+          },
+          {
+            "ansible-version": "stable-2.11",
+            "python-version": "3.10"
+          }
+        ]
+
   unit-galaxy:
     uses: ansible-network/github_actions/.github/workflows/unit_simple.yml@main
 

--- a/changelogs/fragments/181.yaml
+++ b/changelogs/fragments/181.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add exclusions for certain sanity tests


### PR DESCRIPTION
Add exclusions for sanity where specific python version combinations are not available for the ansible-test sanity command line