### PR TITLE
CI for only PRs, not on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: Test collection
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/changelogs/fragments/184.yaml
+++ b/changelogs/fragments/184.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Disable CI runs with push to main


### PR DESCRIPTION
- limit CI runs to PRs so the job is not triggered after the Pr is merged creating a push to main.