### PR TITLE
Enable update docs via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 ---
-ci:
-  skip:
-    # pre-commit.ci has trouble with this one
-    - update-docs
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/changelogs/fragments/186.yaml
+++ b/changelogs/fragments/186.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Enable update-docs via pre-commit

--- a/docs/ansible.utils.get_path_lookup.rst
+++ b/docs/ansible.utils.get_path_lookup.rst
@@ -51,7 +51,8 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>The <em>path</em> in the <em>var</em> to retrieve the value of. The <em>path</em> needs to a be a valid jinja path.</div>
+                        <div>The <em>path</em> in the <em>var</em> to retrieve the value of.</div>
+                        <div>The <em>path</em> needs to a be a valid jinja path.</div>
                 </td>
             </tr>
             <tr>
@@ -90,7 +91,9 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>If set to <code>True</code>, the return value will always be a list. This can also be accomplished using <code>query</code> or <code>q</code> instead of <code>lookup</code>. <a href='https://docs.ansible.com/ansible/latest/plugins/lookup.html'>https://docs.ansible.com/ansible/latest/plugins/lookup.html</a>.</div>
+                        <div>If set to <code>True</code>, the return value will always be a list.</div>
+                        <div>This can also be accomplished using <code>query</code> or <code>q</code> instead of <code>lookup</code>.</div>
+                        <div><a href='https://docs.ansible.com/ansible/latest/plugins/lookup.html'>https://docs.ansible.com/ansible/latest/plugins/lookup.html</a>.</div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.index_of_lookup.rst
+++ b/docs/ansible.utils.index_of_lookup.rst
@@ -91,7 +91,9 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>When the data provided is a list of dictionaries, run the test against this dictionary key. When using a <em>key</em>, the <em>data</em> must only contain dictionaries. See <em>fail_on_missing</em> below to determine the behaviour when the <em>key</em> is missing from a dictionary in the <em>data</em>.</div>
+                        <div>When the data provided is a list of dictionaries, run the test against this dictionary key.</div>
+                        <div>When using a <em>key</em>, the <em>data</em> must only contain dictionaries.</div>
+                        <div>See <em>fail_on_missing</em> below to determine the behaviour when the <em>key</em> is missing from a dictionary in the <em>data</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -109,7 +111,9 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>The name of the test to run against the list, a valid jinja2 test or ansible test plugin. Jinja2 includes the following tests <a href='http://jinja.palletsprojects.com/templates/#builtin-tests'>http://jinja.palletsprojects.com/templates/#builtin-tests</a>. An overview of tests included in ansible <a href='https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html'>https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html</a>.</div>
+                        <div>The name of the test to run against the list, a valid jinja2 test or ansible test plugin.</div>
+                        <div>Jinja2 includes the following tests <a href='http://jinja.palletsprojects.com/templates/#builtin-tests'>http://jinja.palletsprojects.com/templates/#builtin-tests</a>.</div>
+                        <div>An overview of tests included in ansible <a href='https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html'>https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html</a>.</div>
                 </td>
             </tr>
             <tr>
@@ -126,7 +130,9 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>The value used to test each list item against. Not required for simple tests (eg: <code>true</code>, <code>false</code>, <code>even</code>, <code>odd</code>) May be a <code>string</code>, <code>boolean</code>, <code>number</code>, <code>regular expression</code> <code>dict</code> and so on, depending on the <b>test</b> used.</div>
+                        <div>The value used to test each list item against.</div>
+                        <div>Not required for simple tests (e.g. <code>true</code>, <code>false</code>, <code>even</code>, <code>odd</code>)</div>
+                        <div>May be a <code>string</code>, <code>boolean</code>, <code>number</code>, <code>regular expression</code> <code>dict</code> and so on, depending on the <b>test</b> used.</div>
                 </td>
             </tr>
             <tr>
@@ -147,7 +153,10 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>When only a single entry in the <em>data</em> is matched, the index of that entry is returned as an integer. If set to <code>True</code>, the return value will always be a list, even if only a single entry is matched. This can also be accomplished using <code>query</code> or <code>q</code> instead of <code>lookup</code>. <a href='https://docs.ansible.com/ansible/latest/plugins/lookup.html'>https://docs.ansible.com/ansible/latest/plugins/lookup.html</a></div>
+                        <div>When only a single entry in the <em>data</em> is matched, the index of that entry is returned as an integer.</div>
+                        <div>If set to <code>True</code>, the return value will always be a list, even if only a single entry is matched.</div>
+                        <div>This can also be accomplished using <code>query</code> or <code>q</code> instead of <code>lookup</code>.</div>
+                        <div><a href='https://docs.ansible.com/ansible/latest/plugins/lookup.html'>https://docs.ansible.com/ansible/latest/plugins/lookup.html</a></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.to_paths_lookup.rst
+++ b/docs/ansible.utils.to_paths_lookup.rst
@@ -91,7 +91,9 @@ Parameters
                     <td>
                     </td>
                 <td>
-                        <div>If set to <em>True</em>, the return value will always be a list. This can also be accomplished using <code>query</code> or <b>q</b> instead of <code>lookup</code>. <a href='https://docs.ansible.com/ansible/latest/plugins/lookup.html'>https://docs.ansible.com/ansible/latest/plugins/lookup.html</a></div>
+                        <div>If set to <em>True</em>, the return value will always be a list.</div>
+                        <div>This can also be accomplished using <code>query</code> or <b>q</b> instead of <code>lookup</code>.</div>
+                        <div><a href='https://docs.ansible.com/ansible/latest/plugins/lookup.html'>https://docs.ansible.com/ansible/latest/plugins/lookup.html</a></div>
                 </td>
             </tr>
     </table>

--- a/plugins/lookup/index_of.py
+++ b/plugins/lookup/index_of.py
@@ -17,7 +17,7 @@ DOCUMENTATION = """
     author: Bradley Thornton (@cidrblock)
     version_added: "1.0.0"
     short_description: Find the indices of items in a list matching some criteria
-    description: foo
+    description:
       - This plugin returns the indices of items matching some criteria in a list.
       - When working with a list of dictionaries, the key to evaluate can be specified.
       - B(index_of) is also available as a B(filter plugin) for convenience.


### PR DESCRIPTION
##### SUMMARY
Enable update docs for precommit
- doc changes made by pre-commit/update_docs
- reverts the `foo` added during test that snuck in with #172 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pre-commit

##### ADDITIONAL INFORMATION
