### PR TITLE
Enable prettier via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,38 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main]
       - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.6.2"
+    hooks:
+      - id: prettier
+        # Original hook implementation is flaky due to *several* bugs described
+        # in https://github.com/prettier/prettier/issues/12364
+        # a) CI=1 needed to avoid incomplete output
+        # b) two executions are needed because --list-different works correctly
+        # only when run with --check as with --write the output will also
+        # include other entries and logging level cannot be used to keep only
+        # modified files listed (any file is listed using the log level, regardless if
+        # is modified or not).
+        # c) We avoid letting pre-commit pass each filename in order to avoid
+        # running multiple instances in parallel. This also ensures that running
+        # prettier from the command line behaves identically with the pre-commit
+        # one. No real performance downsides.
+        # d) exit with the return code from list-different (0=none, 1=some)
+        # rather than the write (0=successfully rewrote files). pre-commit.ci
+        entry: env CI=1 bash -c "prettier --list-different . || ec=$? && prettier --loglevel=error --write . && exit $ec"
+        pass_filenames: false
+        args: []
+        additional_dependencies:
+          - prettier
+          - prettier-plugin-toml
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
         args: [-l, "79"]
+
   - repo: https://github.com/ansible-network/collection_prep
     rev: 1.0.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# Stuff we don't want priettier to ever to look into
+.*/
+coverage/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# A linked collection directory created by pytest-ansible-units
+collections/
+
+README.md


### PR DESCRIPTION
##### SUMMARY
Enable prettier via pre-commit

##### ISSUE TYPE
CI imporvements

##### COMPONENT NAME
pre-commit.ci

##### ADDITIONAL INFORMATION
Only the prettier ignore file and pre-commit config were modified for the PR, all other changes made by pre-commit
