### PR TITLE
Add isort, increase black line length

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,5 +3,4 @@ known_first_party=ansible_collections.ansible.utils
 line_length=100
 lines_after_imports=2
 lines_between_types=1
-no_lines_before="LOCALFOLDER"
 profile=black

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+force_single_line=false
+known_first_party=ansible_collections.ansible.utils
+lines_after_imports=2
+lines_between_types=1
+line_length=100
+no_lines_before="LOCALFOLDER"
+profile=black

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,7 @@
 [settings]
-force_single_line=false
 known_first_party=ansible_collections.ansible.utils
+line_length=100
 lines_after_imports=2
 lines_between_types=1
-line_length=100
 no_lines_before="LOCALFOLDER"
 profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,11 +35,16 @@ repos:
           - prettier
           - prettier-plugin-toml
 
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: Sort import statements using isort
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        args: [-l, "79"]
 
   - repo: https://github.com/ansible-network/collection_prep
     rev: 1.0.0

--- a/changelogs/fragments/189.yaml
+++ b/changelogs/fragments/189.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Enable isort, increase black line length to 100

--- a/plugins/action/cli_parse.py
+++ b/plugins/action/cli_parse.py
@@ -8,24 +8,24 @@ The action plugin file for cli_parse
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import json
+
 from importlib import import_module
 
 from ansible.errors import AnsibleActionFail
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.connection import (
-    Connection,
-    ConnectionError as AnsibleConnectionError,
-)
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import ConnectionError as AnsibleConnectionError
 from ansible.plugins.action import ActionBase
-from ansible_collections.ansible.utils.plugins.modules.cli_parse import (
-    DOCUMENTATION,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+from ansible_collections.ansible.utils.plugins.modules.cli_parse import DOCUMENTATION
+
 
 # python 2.7 compat for FileNotFoundError
 try:
@@ -35,9 +35,7 @@ except NameError:
 
 
 ARGSPEC_CONDITIONALS = {
-    "argument_spec": {
-        "parser": {"mutually_exclusive": [["command", "template_path"]]}
-    },
+    "argument_spec": {"parser": {"mutually_exclusive": [["command", "template_path"]]}},
     "required_one_of": [["command", "text"]],
     "mutually_exclusive": [["command", "text"]],
 }
@@ -61,9 +59,7 @@ class ActionModule(ActionBase):
         :param msg: The message
         :type msg: str
         """
-        msg = "<{phost}> [cli_parse] {msg}".format(
-            phost=self._playhost, msg=msg
-        )
+        msg = "<{phost}> [cli_parse] {msg}".format(phost=self._playhost, msg=msg)
         self._display.vvvv(msg)
 
     def _fail_json(self, msg):
@@ -108,9 +104,7 @@ class ActionModule(ActionBase):
         :rtype: CliParser
         """
         requested_parser = self._task.args.get("parser").get("name")
-        cref = dict(
-            zip(["corg", "cname", "plugin"], requested_parser.split("."))
-        )
+        cref = dict(zip(["corg", "cname", "plugin"], requested_parser.split(".")))
         if cref["cname"] == "netcommon" and cref["plugin"] in [
             "json",
             "textfsm",
@@ -121,9 +115,7 @@ class ActionModule(ActionBase):
             msg = (
                 "Use 'ansible.utils.{plugin}' for parser name instead of '{requested_parser}'."
                 " This feature will be removed from 'ansible.netcommon' collection in a release"
-                " after 2022-11-01".format(
-                    plugin=cref["plugin"], requested_parser=requested_parser
-                )
+                " after 2022-11-01".format(plugin=cref["plugin"], requested_parser=requested_parser)
             )
             self._display.warning(msg)
 
@@ -147,13 +139,13 @@ class ActionModule(ActionBase):
                 "ntc",
                 "pyats",
             ]:
-                parserlib = "ansible_collections.{corg}.{cname}.plugins.cli_parsers.{plugin}_parser".format(
-                    **cref
+                parserlib = (
+                    "ansible_collections.{corg}.{cname}.plugins.cli_parsers.{plugin}_parser".format(
+                        **cref
+                    )
                 )
                 try:
-                    parsercls = getattr(
-                        import_module(parserlib), self.PARSER_CLS_NAME
-                    )
+                    parsercls = getattr(import_module(parserlib), self.PARSER_CLS_NAME)
                     parser = parsercls(
                         task_args=self._task.args,
                         task_vars=task_vars,
@@ -162,24 +154,18 @@ class ActionModule(ActionBase):
                     return parser
                 except Exception as exc:
                     self._result["failed"] = True
-                    self._result["msg"] = "Error loading parser: {err}".format(
-                        err=to_native(exc)
-                    )
+                    self._result["msg"] = "Error loading parser: {err}".format(err=to_native(exc))
                     return None
 
             self._result["failed"] = True
-            self._result["msg"] = "Error loading parser: {err}".format(
-                err=to_native(exc)
-            )
+            self._result["msg"] = "Error loading parser: {err}".format(err=to_native(exc))
             return None
 
     def _set_parser_command(self):
         """Set the /parser/command in the task args based on /command if needed"""
         if self._task.args.get("command"):
             if not self._task.args.get("parser").get("command"):
-                self._task.args.get("parser")["command"] = self._task.args.get(
-                    "command"
-                )
+                self._task.args.get("parser")["command"] = self._task.args.get("command")
 
     def _set_text(self):
         """Set the /text in the task_args based on the command run"""
@@ -205,11 +191,7 @@ class ActionModule(ActionBase):
                     )
                 else:
                     oper_sys = self._task_vars.get(hvar)
-                    self._debug(
-                        "OS set to {os}, using {key}".format(
-                            os=oper_sys.lower(), key=hvar
-                        )
-                    )
+                    self._debug("OS set to {os}, using {key}".format(os=oper_sys.lower(), key=hvar))
         return oper_sys.lower()
 
     def _update_template_path(self, template_extension):
@@ -224,18 +206,10 @@ class ActionModule(ActionBase):
                 oper_sys = self._task.args.get("parser").get("os")
             else:
                 oper_sys = self._os_from_task_vars()
-            cmd_as_fname = (
-                self._task.args.get("parser").get("command").replace(" ", "_")
-            )
-            fname = "{os}_{cmd}.{ext}".format(
-                os=oper_sys, cmd=cmd_as_fname, ext=template_extension
-            )
+            cmd_as_fname = self._task.args.get("parser").get("command").replace(" ", "_")
+            fname = "{os}_{cmd}.{ext}".format(os=oper_sys, cmd=cmd_as_fname, ext=template_extension)
             source = self._find_needle("templates", fname)
-            self._debug(
-                "template_path in task args updated to {source}".format(
-                    source=source
-                )
-            )
+            self._debug("template_path in task args updated to {source}".format(source=source))
             self._task.args["parser"]["template_path"] = source
 
     def _get_template_contents(self):
@@ -254,9 +228,7 @@ class ActionModule(ActionBase):
                             file_handler.read(), errors="surrogate_or_strict"
                         )
                     except UnicodeError:
-                        raise AnsibleActionFail(
-                            "Template source files must be utf-8 encoded"
-                        )
+                        raise AnsibleActionFail("Template source files must be utf-8 encoded")
             except FileNotFoundError as exc:
                 raise AnsibleActionFail(
                     "Failed to open template '{tpath}'. Error: {err}".format(
@@ -364,9 +336,7 @@ class ActionModule(ActionBase):
 
         if result.get("errors"):
             self._prune_result()
-            self._result.update(
-                {"failed": True, "msg": " ".join(result["errors"])}
-            )
+            self._result.update({"failed": True, "msg": " ".join(result["errors"])})
         else:
             self._result["parsed"] = result["parsed"]
             set_fact = self._task.args.get("set_fact")

--- a/plugins/action/fact_diff.py
+++ b/plugins/action/fact_diff.py
@@ -5,18 +5,20 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
+
 from importlib import import_module
-from ansible.plugins.action import ActionBase
+
 from ansible.module_utils._text import to_native
-from ansible_collections.ansible.utils.plugins.modules.fact_diff import (
-    DOCUMENTATION,
-)
+from ansible.plugins.action import ActionBase
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.modules.fact_diff import DOCUMENTATION
 
 
 class ActionModule(ActionBase):
@@ -69,8 +71,10 @@ class ActionModule(ActionBase):
             return None
         cref = dict(zip(["corg", "cname", "plugin"], plugin.split(".")))
         cref.update(directory=directory)
-        parserlib = "ansible_collections.{corg}.{cname}.plugins.sub_plugins.{directory}.{plugin}".format(
-            **cref
+        parserlib = (
+            "ansible_collections.{corg}.{cname}.plugins.sub_plugins.{directory}.{plugin}".format(
+                **cref
+            )
         )
         try:
             class_obj = getattr(import_module(parserlib), class_name)
@@ -82,9 +86,7 @@ class ActionModule(ActionBase):
             return class_instance
         except Exception as exc:
             self._result["failed"] = True
-            self._result[
-                "msg"
-            ] = "Error loading plugin '{plugin}': {err}".format(
+            self._result["msg"] = "Error loading plugin '{plugin}': {err}".format(
                 plugin=plugin, err=to_native(exc)
             )
             return None
@@ -116,9 +118,7 @@ class ActionModule(ActionBase):
             return self._result
 
         self._plugin = self._task.args["plugin"]["name"]
-        plugin_instance = self._load_plugin(
-            self._plugin, "fact_diff", "FactDiff"
-        )
+        plugin_instance = self._load_plugin(self._plugin, "fact_diff", "FactDiff")
         if self._result.get("failed"):
             return self._result
 

--- a/plugins/action/update_fact.py
+++ b/plugins/action/update_fact.py
@@ -5,26 +5,22 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import ast
 import re
-from ansible.plugins.action import ActionBase
 
-from ansible.module_utils.common._collections_compat import (
-    MutableMapping,
-    MutableSequence,
-)
-
+from ansible.errors import AnsibleActionFail
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common._collections_compat import MutableMapping, MutableSequence
+from ansible.plugins.action import ActionBase
 from jinja2 import Template, TemplateSyntaxError
-from ansible_collections.ansible.utils.plugins.modules.update_fact import (
-    DOCUMENTATION,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
-from ansible.errors import AnsibleActionFail
+from ansible_collections.ansible.utils.plugins.modules.update_fact import DOCUMENTATION
 
 
 class ActionModule(ActionBase):
@@ -120,9 +116,8 @@ class ActionModule(ActionBase):
             try:
                 new_obj = obj[first]
             except (KeyError, TypeError):
-                msg = (
-                    "Error: the key '{first}' was not found "
-                    "in {obj}.".format(obj=obj, first=first)
+                msg = "Error: the key '{first}' was not found " "in {obj}.".format(
+                    obj=obj, first=first
                 )
                 raise AnsibleActionFail(msg)
             self.set_value(new_obj, rest, val)
@@ -167,9 +162,7 @@ class ActionModule(ActionBase):
             obj, path = parts[0], parts[1:]
             results.add(obj)
             if obj not in task_vars["vars"]:
-                msg = "'{obj}' was not found in the current facts.".format(
-                    obj=obj
-                )
+                msg = "'{obj}' was not found in the current facts.".format(obj=obj)
                 raise AnsibleActionFail(msg)
             retrieved = task_vars["vars"].get(obj)
             if path:

--- a/plugins/action/validate.py
+++ b/plugins/action/validate.py
@@ -8,21 +8,19 @@ The action plugin file for validate
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 from ansible.errors import AnsibleActionFail, AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.plugins.action import ActionBase
 
-from ansible_collections.ansible.utils.plugins.modules.validate import (
-    DOCUMENTATION,
-)
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    _load_validator,
-)
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+from ansible_collections.ansible.utils.plugins.modules.validate import DOCUMENTATION
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import _load_validator
+
 
 ARGSPEC_CONDITIONALS = {}
 
@@ -43,9 +41,7 @@ class ActionModule(ActionBase):
         :param msg: The message
         :type msg: str
         """
-        msg = "<{phost}> {name} {msg}".format(
-            phost=self._playhost, name=name, msg=msg
-        )
+        msg = "<{phost}> {name} {msg}".format(phost=self._playhost, name=name, msg=msg)
         self._display.vvvv(msg)
 
     def run(self, tmp=None, task_vars=None):
@@ -68,9 +64,7 @@ class ActionModule(ActionBase):
             return argspec_result
 
         self._task_vars = task_vars
-        self._playhost = (
-            task_vars.get("inventory_hostname") if task_vars else None
-        )
+        self._playhost = task_vars.get("inventory_hostname") if task_vars else None
 
         self._validator_engine, validator_result = _load_validator(
             engine=updated_params["engine"],
@@ -84,9 +78,7 @@ class ActionModule(ActionBase):
         try:
             result = self._validator_engine.validate()
         except AnsibleError as exc:
-            raise AnsibleActionFail(
-                to_text(exc, errors="surrogate_then_replace")
-            )
+            raise AnsibleActionFail(to_text(exc, errors="surrogate_then_replace"))
         except Exception as exc:
             raise AnsibleActionFail(
                 "Unhandled exception from validator '{validator}'. Error: {err}".format(
@@ -100,9 +92,7 @@ class ActionModule(ActionBase):
             self._result["errors"] = result["errors"]
             self._result.update({"failed": True})
             if "msg" in result:
-                self._result["msg"] = (
-                    "Validation errors were found.\n" + result["msg"]
-                )
+                self._result["msg"] = "Validation errors were found.\n" + result["msg"]
             else:
                 self._result["msg"] = "Validation errors were found."
 

--- a/plugins/filter/cidr_merge.py
+++ b/plugins/filter/cidr_merge.py
@@ -7,14 +7,18 @@
 filter plugin file for ipaddr filters: cidr_merge
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    _need_netaddr,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
+    _need_netaddr,
+)
+
 
 __metaclass__ = type
 
@@ -132,9 +136,7 @@ def _cidr_merge(*args, **kwargs):
     keys = ["value", "action"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="cidr_merge"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="cidr_merge")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -143,9 +145,7 @@ def _cidr_merge(*args, **kwargs):
 
 def cidr_merge(value, action="merge"):
     if not hasattr(value, "__iter__"):
-        raise AnsibleFilterError(
-            "cidr_merge: expected iterable, got " + repr(value)
-        )
+        raise AnsibleFilterError("cidr_merge: expected iterable, got " + repr(value))
 
     if action == "merge":
         try:
@@ -161,16 +161,12 @@ def cidr_merge(value, action="merge"):
             try:
                 return str(netaddr.IPNetwork(value[0]))
             except Exception as e:
-                raise AnsibleFilterError(
-                    "cidr_merge: error in netaddr:\n%s" % e
-                )
+                raise AnsibleFilterError("cidr_merge: error in netaddr:\n%s" % e)
         else:
             try:
                 return str(netaddr.spanning_cidr(value))
             except Exception as e:
-                raise AnsibleFilterError(
-                    "cidr_merge: error in netaddr:\n%s" % e
-                )
+                raise AnsibleFilterError("cidr_merge: error in netaddr:\n%s" % e)
 
     else:
         raise AnsibleFilterError("cidr_merge: invalid action '%s'" % action)
@@ -189,6 +185,4 @@ class FilterModule(object):
             return self.filter_map
         else:
             # Need to install python's netaddr for these filters to work
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/consolidate.py
+++ b/plugins/filter/consolidate.py
@@ -10,6 +10,7 @@ The consolidate filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -1443,12 +1444,12 @@ tasks:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.consolidate import (
-    consolidate,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.consolidate import consolidate
+
 
 try:
     from jinja2.filters import pass_environment
@@ -1468,9 +1469,7 @@ def _consolidate(*args, **kwargs):
     ]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="consolidate"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="consolidate")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/from_xml.py
+++ b/plugins/filter/from_xml.py
@@ -10,6 +10,7 @@ The from_xml filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -111,12 +112,12 @@ tasks:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.from_xml import (
-    from_xml,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.from_xml import from_xml
+
 
 try:
     from jinja2.filters import pass_environment
@@ -131,9 +132,7 @@ def _from_xml(*args, **kwargs):
     keys = ["data", "engine"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="from_xml"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="from_xml")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/get_path.py
+++ b/plugins/filter/get_path.py
@@ -9,6 +9,7 @@ flatten a complex object to dot bracket notation
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -148,13 +149,12 @@ EXAMPLES = r"""
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import (
-    get_path,
-)
 
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import get_path
+
 
 try:
     from jinja2.filters import pass_environment
@@ -169,9 +169,7 @@ def _get_path(*args, **kwargs):
     data = dict(zip(keys, args))
     data.update(kwargs)
     environment = data.pop("environment")
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="get_path"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="get_path")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/hwaddr.py
+++ b/plugins/filter/hwaddr.py
@@ -7,15 +7,19 @@
 filter plugin file for ipaddr filters: hwaddr
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
+
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+    AnsibleArgSpecValidator,
+)
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
     _need_netaddr,
     hwaddr,
 )
-from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
-    AnsibleArgSpecValidator,
-)
+
 
 __metaclass__ = type
 
@@ -102,9 +106,7 @@ def _hwaddr(*args, **kwargs):
     keys = ["value", "query", "alias"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="hwaddr"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="hwaddr")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -124,6 +126,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/index_of.py
+++ b/plugins/filter/index_of.py
@@ -9,6 +9,7 @@ The index_of filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -298,12 +299,12 @@ EXAMPLES = r"""
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.module_utils.common.index_of import (
-    index_of,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.index_of import index_of
+
 
 try:
     from jinja2.filters import pass_environment
@@ -327,9 +328,7 @@ def _index_of(*args, **kwargs):
     data = dict(zip(keys, args))
     data.update(kwargs)
     environment = data.pop("environment")
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="index_of"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="index_of")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/ip4_hex.py
+++ b/plugins/filter/ip4_hex.py
@@ -7,14 +7,16 @@
 filter plugin file for ipaddr filters: ip4_hex
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    _need_netaddr,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import _need_netaddr
+
 
 __metaclass__ = type
 
@@ -99,9 +101,7 @@ def _ip4_hex(*args, **kwargs):
     keys = ["arg", "delimiter"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="ip4_hex"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ip4_hex")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -111,9 +111,7 @@ def _ip4_hex(*args, **kwargs):
 def ip4_hex(arg, delimiter=""):
     """Convert an IPv4 address to Hexadecimal notation"""
     numbers = list(map(int, arg.split(".")))
-    return "{0:02x}{sep}{1:02x}{sep}{2:02x}{sep}{3:02x}".format(
-        *numbers, sep=delimiter
-    )
+    return "{0:02x}{sep}{1:02x}{sep}{2:02x}{sep}{3:02x}".format(*numbers, sep=delimiter)
 
 
 class FilterModule(object):
@@ -129,6 +127,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -7,16 +7,19 @@
 filter plugin file for ipaddr filters: cidr_merge
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-)
-from ansible.errors import AnsibleFilterError
-from ansible.errors import AnsibleError
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -266,14 +269,10 @@ def _ipaddr(*args, **kwargs):
 
     except (TypeError, ValueError):
         raise AnsibleError(
-            "Unrecognized type <{0}> for ipaddr filter <{1}>".format(
-                type(data["value"]), "value"
-            )
+            "Unrecognized type <{0}> for ipaddr filter <{1}>".format(type(data["value"]), "value")
         )
 
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="ipaddr"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipaddr")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -293,6 +292,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/ipmath.py
+++ b/plugins/filter/ipmath.py
@@ -7,14 +7,16 @@
 filter plugin file for ipaddr filters: cidr_merge
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    _need_netaddr,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import _need_netaddr
+
 
 __metaclass__ = type
 
@@ -139,9 +141,7 @@ def _ipmath(*args, **kwargs):
     keys = ["value", "amount"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="ipmath"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipmath")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -159,10 +159,9 @@ def ipmath(value, amount):
         raise AnsibleFilterError(msg)
 
     if not isinstance(amount, int):
-        msg = (
-            "You must pass an integer for arithmetic; "
-            "{0} is not a valid integer"
-        ).format(amount)
+        msg = ("You must pass an integer for arithmetic; " "{0} is not a valid integer").format(
+            amount
+        )
         raise AnsibleFilterError(msg)
 
     return str(ip + amount)
@@ -181,6 +180,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/ipsubnet.py
+++ b/plugins/filter/ipsubnet.py
@@ -7,15 +7,19 @@
 filter plugin file for ipaddr filters: ipsubnet
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -243,9 +247,7 @@ def _ipsubnet(*args, **kwargs):
     keys = ["value", "query", "index"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="ipsubnet"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipsubnet")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -309,9 +311,7 @@ def ipsubnet(value, query="", index="x"):
         elif vtype == "network":
             v = ipaddr(query, "subnet")
         else:
-            msg = "You must pass a valid subnet or IP address; {0} is invalid".format(
-                query_string
-            )
+            msg = "You must pass a valid subnet or IP address; {0} is invalid".format(query_string)
             raise AnsibleFilterError(msg)
         query = netaddr.IPNetwork(v)
         for i, subnet in enumerate(query.subnet(value.prefixlen), 1):
@@ -335,6 +335,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/ipv4.py
+++ b/plugins/filter/ipv4.py
@@ -7,16 +7,19 @@
 filter plugin file for ipaddr filters: ipv4
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-)
-from ansible.errors import AnsibleFilterError
-from ansible.errors import AnsibleError
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -137,16 +140,12 @@ def _ipv4(*args, **kwargs):
             pass
         else:
             raise AnsibleError(
-                "Unrecognized type <{0}> for ipv4 filter <{1}>".format(
-                    type(data["value"]), "value"
-                )
+                "Unrecognized type <{0}> for ipv4 filter <{1}>".format(type(data["value"]), "value")
             )
 
     except (TypeError, ValueError):
         raise AnsibleError(
-            "Unrecognized type <{0}> for ipv4 filter <{1}>".format(
-                type(data["value"]), "value"
-            )
+            "Unrecognized type <{0}> for ipv4 filter <{1}>".format(type(data["value"]), "value")
         )
     aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipv4")
     valid, errors, updated_data = aav.validate()
@@ -172,6 +171,4 @@ class FilterModule(object):
         if netaddr:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/ipv6.py
+++ b/plugins/filter/ipv6.py
@@ -7,16 +7,19 @@
 filter plugin file for ipaddr filters: ipv6
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-)
-from ansible.errors import AnsibleFilterError
-from ansible.errors import AnsibleError
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -155,16 +158,12 @@ def _ipv6(*args, **kwargs):
             pass
         else:
             raise AnsibleError(
-                "Unrecognized type <{0}> for ipv6 filter <{1}>".format(
-                    type(data["value"]), "value"
-                )
+                "Unrecognized type <{0}> for ipv6 filter <{1}>".format(type(data["value"]), "value")
             )
 
     except (TypeError, ValueError):
         raise AnsibleError(
-            "Unrecognized type <{0}> for ipv6 filter <{1}>".format(
-                type(data["value"]), "value"
-            )
+            "Unrecognized type <{0}> for ipv6 filter <{1}>".format(type(data["value"]), "value")
         )
     aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipv6")
     valid, errors, updated_data = aav.validate()
@@ -190,6 +189,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/ipwrap.py
+++ b/plugins/filter/ipwrap.py
@@ -7,17 +7,21 @@
 filter plugin file for ipaddr filters: ipwrap
 """
 from __future__ import absolute_import, division, print_function
-from functools import partial
+
 import types
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-)
-from ansible.errors import AnsibleFilterError
-from ansible.errors import AnsibleError
+
+from functools import partial
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -164,13 +168,9 @@ def _ipwrap(*args, **kwargs):
 
     except (TypeError, ValueError):
         raise AnsibleError(
-            "Unrecognized type <{0}> for ipwrap filter <{1}>".format(
-                type(data["value"]), "value"
-            )
+            "Unrecognized type <{0}> for ipwrap filter <{1}>".format(type(data["value"]), "value")
         )
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="ipwrap"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipwrap")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -212,6 +212,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/keep_keys.py
+++ b/plugins/filter/keep_keys.py
@@ -10,6 +10,7 @@ The keep_keys filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -293,12 +294,12 @@ tasks:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.keep_keys import (
-    keep_keys,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.keep_keys import keep_keys
+
 
 try:
     from jinja2.filters import pass_environment
@@ -313,9 +314,7 @@ def _keep_keys(*args, **kwargs):
     keys = ["data", "target", "matching_parameter"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="keep_keys"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="keep_keys")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/macaddr.py
+++ b/plugins/filter/macaddr.py
@@ -7,15 +7,19 @@
 filter plugin file for ipaddr filters: macaddr
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
+
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+    AnsibleArgSpecValidator,
+)
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
     _need_netaddr,
     hwaddr,
 )
-from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
-    AnsibleArgSpecValidator,
-)
+
 
 __metaclass__ = type
 
@@ -99,9 +103,7 @@ def _macaddr(*args, **kwargs):
     keys = ["value", "query"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="macaddr"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="macaddr")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -125,6 +127,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/network_in_network.py
+++ b/plugins/filter/network_in_network.py
@@ -7,17 +7,21 @@
 filter plugin file for ipaddr filters: network_in_network
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-    _address_normalizer,
-    _range_checker,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _address_normalizer,
+    _need_netaddr,
+    _range_checker,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -112,9 +116,7 @@ def _network_in_network(*args, **kwargs):
     keys = ["value", "test"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="network_in_network"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="network_in_network")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -138,9 +140,7 @@ def network_in_network(value, test):
     w_first = ipaddr(ipaddr(w, "network") or ipaddr(w, "address"), "int")
     w_last = ipaddr(ipaddr(w, "broadcast") or ipaddr(w, "address"), "int")
 
-    if _range_checker(w_first, v_first, v_last) and _range_checker(
-        w_last, v_first, v_last
-    ):
+    if _range_checker(w_first, v_first, v_last) and _range_checker(w_last, v_first, v_last):
         return True
     else:
         return False
@@ -159,6 +159,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/network_in_usable.py
+++ b/plugins/filter/network_in_usable.py
@@ -7,17 +7,21 @@
 filter plugin file for ipaddr filters: network_in_usable
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-    _address_normalizer,
-    _range_checker,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _address_normalizer,
+    _need_netaddr,
+    _range_checker,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -114,9 +118,7 @@ def _network_in_usable(*args, **kwargs):
     keys = ["value", "test"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="network_in_usable"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="network_in_usable")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -140,9 +142,7 @@ def network_in_usable(value, test):
     w_first = ipaddr(ipaddr(w, "network") or ipaddr(w, "address"), "int")
     w_last = ipaddr(ipaddr(w, "broadcast") or ipaddr(w, "address"), "int")
 
-    if _range_checker(w_first, v_first, v_last) and _range_checker(
-        w_last, v_first, v_last
-    ):
+    if _range_checker(w_first, v_first, v_last) and _range_checker(w_last, v_first, v_last):
         return True
     else:
         return False
@@ -161,6 +161,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/next_nth_usable.py
+++ b/plugins/filter/next_nth_usable.py
@@ -7,16 +7,20 @@
 filter plugin file for ipaddr filters: ipv4
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-    _first_last,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _first_last,
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -103,9 +107,7 @@ def _next_nth_usable(*args, **kwargs):
     keys = ["value", "offset"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="next_nth_usable"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="next_nth_usable")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -149,6 +151,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/nthhost.py
+++ b/plugins/filter/nthhost.py
@@ -7,15 +7,19 @@
 filter plugin file for ipaddr filters: nthhost
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -100,9 +104,7 @@ def _nthhost(*args, **kwargs):
     keys = ["value", "query"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="nthhost"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="nthhost")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -149,6 +151,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/param_list_compare.py
+++ b/plugins/filter/param_list_compare.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -154,9 +155,11 @@ RETURN = """
 """
 
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+
 
 ARGSPEC_CONDITIONALS = {}
 
@@ -173,10 +176,7 @@ def param_list_compare(*args, **kwargs):
         )
 
     valid, argspec_result, updated_params = check_argspec(
-        DOCUMENTATION,
-        "param_list_compare filter",
-        schema_conditionals=ARGSPEC_CONDITIONALS,
-        **data
+        DOCUMENTATION, "param_list_compare filter", schema_conditionals=ARGSPEC_CONDITIONALS, **data
     )
     if not valid:
         raise AnsibleFilterError(
@@ -191,12 +191,8 @@ def param_list_compare(*args, **kwargs):
     alls = [x for x in other if x == "all"]
     bangs = [x[1:] for x in other if x.startswith("!")]
     rbangs = [x for x in other if x.startswith("!")]
-    remain = [
-        x for x in other if x not in alls and x not in rbangs and x in base
-    ]
-    unsupported = [
-        x for x in other if x not in alls and x not in rbangs and x not in base
-    ]
+    remain = [x for x in other if x not in alls and x not in rbangs and x in base]
+    unsupported = [x for x in other if x not in alls and x not in rbangs and x not in base]
 
     if alls:
         combined = base

--- a/plugins/filter/previous_nth_usable.py
+++ b/plugins/filter/previous_nth_usable.py
@@ -7,16 +7,20 @@
 filter plugin file for ipaddr filters: previous_nth_usable
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-    _first_last,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _first_last,
+    _need_netaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -102,9 +106,7 @@ def _previous_nth_usable(*args, **kwargs):
     keys = ["value", "offset"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="previous_nth_usable"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="previous_nth_usable")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -148,6 +150,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/reduce_on_network.py
+++ b/plugins/filter/reduce_on_network.py
@@ -7,17 +7,21 @@
 filter plugin file for ipaddr filters: reduce_on_network
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-    _address_normalizer,
-    _range_checker,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _address_normalizer,
+    _need_netaddr,
+    _range_checker,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -94,9 +98,7 @@ def _reduce_on_network(*args, **kwargs):
     keys = ["value", "network"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="reduce_on_network"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="reduce_on_network")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -128,9 +130,7 @@ def reduce_on_network(value, network):
         a_first = ipaddr(ipaddr(a, "network") or ipaddr(a, "address"), "int")
         a_last = ipaddr(ipaddr(a, "broadcast") or ipaddr(a, "address"), "int")
 
-        if _range_checker(a_first, n_first, n_last) and _range_checker(
-            a_last, n_first, n_last
-        ):
+        if _range_checker(a_first, n_first, n_last) and _range_checker(a_last, n_first, n_last):
             r.append(address)
 
     return r
@@ -149,6 +149,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/remove_keys.py
+++ b/plugins/filter/remove_keys.py
@@ -10,6 +10,7 @@ The remove_keys filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -310,12 +311,12 @@ tasks:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.remove_keys import (
-    remove_keys,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.remove_keys import remove_keys
+
 
 try:
     from jinja2.filters import pass_environment
@@ -330,9 +331,7 @@ def _remove_keys(*args, **kwargs):
     keys = ["data", "target", "matching_parameter"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="remove_keys"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="remove_keys")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/replace_keys.py
+++ b/plugins/filter/replace_keys.py
@@ -10,6 +10,7 @@ The replace_keys filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -287,12 +288,12 @@ tasks:
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.replace_keys import (
-    replace_keys,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.replace_keys import replace_keys
+
 
 try:
     from jinja2.filters import pass_environment
@@ -307,9 +308,7 @@ def _replace_keys(*args, **kwargs):
     keys = ["data", "target", "matching_parameter"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="replace_keys"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="replace_keys")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/slaac.py
+++ b/plugins/filter/slaac.py
@@ -7,16 +7,20 @@
 filter plugin file for ipaddr filters: slaac
 """
 from __future__ import absolute_import, division, print_function
+
 from functools import partial
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-    _need_netaddr,
-    hwaddr,
-)
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
+    _need_netaddr,
+    hwaddr,
+    ipaddr,
+)
+
 
 __metaclass__ = type
 
@@ -90,9 +94,7 @@ def _slaac(*args, **kwargs):
     keys = ["value", "query"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="slaac"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="slaac")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)
@@ -141,6 +143,4 @@ class FilterModule(object):
         if HAS_NETADDR:
             return self.filter_map
         else:
-            return dict(
-                (f, partial(_need_netaddr, f)) for f in self.filter_map
-            )
+            return dict((f, partial(_need_netaddr, f)) for f in self.filter_map)

--- a/plugins/filter/to_paths.py
+++ b/plugins/filter/to_paths.py
@@ -9,6 +9,7 @@ flatten a complex object to dot bracket notation
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
@@ -118,12 +119,11 @@ EXAMPLES = r"""
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.module_utils.common.to_paths import (
-    to_paths,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.to_paths import to_paths
 
 
 def _to_paths(*args, **kwargs):
@@ -131,9 +131,7 @@ def _to_paths(*args, **kwargs):
     keys = ["var", "prepend", "wantlist"]
     data = dict(zip(keys, args))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="to_paths"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="to_paths")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/to_xml.py
+++ b/plugins/filter/to_xml.py
@@ -11,6 +11,7 @@ The to_xml filter plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -106,12 +107,12 @@ EXAMPLES = r"""
 """
 
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.to_xml import (
-    to_xml,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.plugin_utils.to_xml import to_xml
+
 
 try:
     from jinja2.filters import pass_environment
@@ -125,9 +126,7 @@ def _to_xml(*args, **kwargs):
     keys = ["data", "engine"]
     data = dict(zip(keys, args[1:]))
     data.update(kwargs)
-    aav = AnsibleArgSpecValidator(
-        data=data, schema=DOCUMENTATION, name="to_xml"
-    )
+    aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="to_xml")
     valid, errors, updated_data = aav.validate()
     if not valid:
         raise AnsibleFilterError(errors)

--- a/plugins/filter/usable_range.py
+++ b/plugins/filter/usable_range.py
@@ -8,15 +8,15 @@ Filter plugin file for usable_range
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ipaddress import IPv4Network, IPv6Network
 
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 
@@ -165,23 +165,15 @@ def _usable_range(ip):
 
     try:
         if ip_network(ip).version == 4:
-            ips = [
-                to_text(usable_ips)
-                for usable_ips in IPv4Network(ensure_text(ip))
-            ]
+            ips = [to_text(usable_ips) for usable_ips in IPv4Network(ensure_text(ip))]
             no_of_ips = IPv4Network(ensure_text(ip)).num_addresses
         if ip_network(ip).version == 6:
-            ips = [
-                to_text(usable_ips)
-                for usable_ips in IPv6Network(ensure_text(ip))
-            ]
+            ips = [to_text(usable_ips) for usable_ips in IPv6Network(ensure_text(ip))]
             no_of_ips = IPv6Network(ensure_text(ip)).num_addresses
 
     except Exception as e:
         raise AnsibleFilterError(
-            "Error while using plugin 'usable_range': {msg}".format(
-                msg=to_text(e)
-            )
+            "Error while using plugin 'usable_range': {msg}".format(msg=to_text(e))
         )
 
     return {"usable_ips": ips, "number_of_ips": no_of_ips}

--- a/plugins/filter/validate.py
+++ b/plugins/filter/validate.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -70,15 +71,12 @@ RETURN = """
 
 from ansible.errors import AnsibleError, AnsibleFilterError
 from ansible.module_utils._text import to_text
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    _load_validator,
-)
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    to_list,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import to_list
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import _load_validator
 
 
 ARGSPEC_CONDITIONALS = {}
@@ -96,10 +94,7 @@ def validate(*args, **kwargs):
         params.update({"engine": kwargs["engine"]})
 
     valid, argspec_result, updated_params = check_argspec(
-        DOCUMENTATION,
-        "validate filter",
-        schema_conditionals=ARGSPEC_CONDITIONALS,
-        **params
+        DOCUMENTATION, "validate filter", schema_conditionals=ARGSPEC_CONDITIONALS, **params
     )
     if not valid:
         raise AnsibleFilterError(

--- a/plugins/lookup/get_path.py
+++ b/plugins/lookup/get_path.py
@@ -9,6 +9,7 @@ The get_path lookup plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
@@ -157,12 +158,11 @@ RETURN = """
 
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
-from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import (
-    get_path,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import get_path
 
 
 class LookupModule(LookupBase):
@@ -172,12 +172,8 @@ class LookupModule(LookupBase):
             terms = dict(zip(keys, terms))
         terms.update(kwargs)
 
-        schema = [
-            v for k, v in globals().items() if k.lower() == "documentation"
-        ]
-        aav = AnsibleArgSpecValidator(
-            data=terms, schema=schema[0], name="get_path"
-        )
+        schema = [v for k, v in globals().items() if k.lower() == "documentation"]
+        aav = AnsibleArgSpecValidator(data=terms, schema=schema[0], name="get_path")
         valid, errors, updated_data = aav.validate()
         if not valid:
             raise AnsibleLookupError(errors)

--- a/plugins/lookup/index_of.py
+++ b/plugins/lookup/index_of.py
@@ -9,6 +9,7 @@ The index_of lookup plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
@@ -319,12 +320,11 @@ RETURN = """
 
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
-from ansible_collections.ansible.utils.plugins.module_utils.common.index_of import (
-    index_of,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.index_of import index_of
 
 
 class LookupModule(LookupBase):
@@ -341,12 +341,8 @@ class LookupModule(LookupBase):
             terms = dict(zip(keys, terms))
         terms.update(kwargs)
 
-        schema = [
-            v for k, v in globals().items() if k.lower() == "documentation"
-        ]
-        aav = AnsibleArgSpecValidator(
-            data=terms, schema=schema[0], name="index_of"
-        )
+        schema = [v for k, v in globals().items() if k.lower() == "documentation"]
+        aav = AnsibleArgSpecValidator(data=terms, schema=schema[0], name="index_of")
         valid, errors, updated_data = aav.validate()
         if not valid:
             raise AnsibleLookupError(errors)

--- a/plugins/lookup/to_paths.py
+++ b/plugins/lookup/to_paths.py
@@ -9,6 +9,7 @@ The to_paths lookup plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
@@ -129,12 +130,11 @@ RETURN = """
 
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
-from ansible_collections.ansible.utils.plugins.module_utils.common.to_paths import (
-    to_paths,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.to_paths import to_paths
 
 
 class LookupModule(LookupBase):
@@ -144,12 +144,8 @@ class LookupModule(LookupBase):
             terms = dict(zip(keys, terms))
         terms.update(kwargs)
 
-        schema = [
-            v for k, v in globals().items() if k.lower() == "documentation"
-        ]
-        aav = AnsibleArgSpecValidator(
-            data=terms, schema=schema[0], name="to_paths"
-        )
+        schema = [v for k, v in globals().items() if k.lower() == "documentation"]
+        aav = AnsibleArgSpecValidator(data=terms, schema=schema[0], name="to_paths")
         valid, errors, updated_data = aav.validate()
         if not valid:
             raise AnsibleLookupError(errors)

--- a/plugins/lookup/validate.py
+++ b/plugins/lookup/validate.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -83,15 +84,12 @@ RETURN = """
 from ansible.errors import AnsibleError, AnsibleLookupError
 from ansible.module_utils._text import to_text
 from ansible.plugins.lookup import LookupBase
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    _load_validator,
-)
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    to_list,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import to_list
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import _load_validator
 
 
 ARGSPEC_CONDITIONALS = {}
@@ -109,9 +107,7 @@ class LookupModule(LookupBase):
         if kwargs.get("engine"):
             params.update({"engine": kwargs["engine"]})
 
-        schema = [
-            v for k, v in globals().items() if k.lower() == "documentation"
-        ]
+        schema = [v for k, v in globals().items() if k.lower() == "documentation"]
         valid, argspec_result, updated_params = check_argspec(
             schema=schema[0],
             name="validate lookup",
@@ -143,9 +139,7 @@ class LookupModule(LookupBase):
         try:
             result = validator_engine.validate()
         except AnsibleError as exc:
-            raise AnsibleLookupError(
-                to_text(exc, errors="surrogate_then_replace")
-            )
+            raise AnsibleLookupError(to_text(exc, errors="surrogate_then_replace"))
         except Exception as exc:
             raise AnsibleLookupError(
                 "Unhandled exception from validator '{validator}'. Error: {err}".format(

--- a/plugins/module_utils/common/argspec_validate.py
+++ b/plugins/module_utils/common/argspec_validate.py
@@ -21,14 +21,16 @@ def _check_argspec(self):
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    dict_merge,
-)
 from ansible.module_utils.six import iteritems
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import dict_merge
+
 
 try:
     import yaml
@@ -104,9 +106,7 @@ class MonkeyModule(AnsibleModule):
         :type msg: str
         """
         if self.name:
-            msg = re.sub(
-                r"\(basic\.pyc?\)", "'{name}'".format(name=self.name), msg
-            )
+            msg = re.sub(r"\(basic\.pyc?\)", "'{name}'".format(name=self.name), msg)
         self._valid = False
         self._errors = msg
 
@@ -181,9 +181,7 @@ class AnsibleArgSpecValidator:
                 if metakey == "suboptions":
                     temp_schema[okey].update({"options": {}})
                     suboptions_obj = {"options": ovalue["suboptions"]}
-                    self._extract_schema_from_doc(
-                        suboptions_obj, temp_schema[okey]["options"]
-                    )
+                    self._extract_schema_from_doc(suboptions_obj, temp_schema[okey]["options"])
                 elif metakey in OPTION_METADATA + OPTION_CONDITIONALS:
                     temp_schema[okey].update({metakey: ovalue[metakey]})
 
@@ -214,9 +212,7 @@ class AnsibleArgSpecValidator:
             self._schema = dict_merge(self._schema, self._schema_conditionals)
         if self._other_args is not None:
             self._schema = dict_merge(self._schema, self._other_args)
-        invalid_keys = [
-            k for k in self._schema.keys() if k not in VALID_ANSIBLEMODULE_ARGS
-        ]
+        invalid_keys = [k for k in self._schema.keys() if k not in VALID_ANSIBLEMODULE_ARGS]
         if invalid_keys:
             valid = False
             errors = "Invalid schema. Invalid keys found: {ikeys}".format(
@@ -224,9 +220,7 @@ class AnsibleArgSpecValidator:
             )
             updated_data = {}
         else:
-            mm = MonkeyModule(
-                data=self._data, schema=self._schema, name=self._name
-            )
+            mm = MonkeyModule(data=self._data, schema=self._schema, name=self._name)
             valid, errors, updated_data = mm.validate()
         return valid, errors, updated_data
 
@@ -239,14 +233,8 @@ class AnsibleArgSpecValidator:
             if self._schema_format == "doc":
                 self._convert_doc_to_schema()
             if self._schema_conditionals is not None:
-                self._schema = dict_merge(
-                    self._schema, self._schema_conditionals
-                )
-            invalid_keys = [
-                k
-                for k in self._schema.keys()
-                if k not in VALID_ANSIBLEMODULE_ARGS
-            ]
+                self._schema = dict_merge(self._schema, self._schema_conditionals)
+            invalid_keys = [k for k in self._schema.keys() if k not in VALID_ANSIBLEMODULE_ARGS]
             if invalid_keys:
                 valid = False
                 errors = [
@@ -269,9 +257,7 @@ class AnsibleArgSpecValidator:
             return self._validate()
 
 
-def check_argspec(
-    schema, name, schema_format="doc", schema_conditionals=None, **args
-):
+def check_argspec(schema, name, schema_format="doc", schema_conditionals=None, **args):
     if schema_conditionals is None:
         schema_conditionals = {}
 
@@ -287,8 +273,6 @@ def check_argspec(
     if not valid:
         result["errors"] = errors
         result["failed"] = True
-        result["msg"] = "argspec validation failed for {name} plugin".format(
-            name=name
-        )
+        result["msg"] = "argspec validation failed for {name} plugin".format(name=name)
 
     return valid, result, updated_params

--- a/plugins/module_utils/common/get_path.py
+++ b/plugins/module_utils/common/get_path.py
@@ -9,6 +9,7 @@ flatten a complex object to dot bracket notation
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/module_utils/common/index_of.py
+++ b/plugins/module_utils/common/index_of.py
@@ -9,12 +9,14 @@ The index_of plugin common code
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import json
 
-from ansible.module_utils.six import string_types, integer_types
 from ansible.module_utils._text import to_native
+from ansible.module_utils.six import integer_types, string_types
+
 
 # Note, this file can only be used on the control node
 # where ansible is installed
@@ -99,9 +101,7 @@ def _run_test(entry, test, right, tests):
 
     j2_test = tests.get(test)
     if not j2_test:
-        msg = "{msg} Error was: the test '{test}' was not found.".format(
-            msg=msg, test=test
-        )
+        msg = "{msg} Error was: the test '{test}' was not found.".format(msg=msg, test=test)
         _raise_error(msg)
     else:
         try:
@@ -110,9 +110,7 @@ def _run_test(entry, test, right, tests):
             else:
                 result = j2_test(entry, right)
         except Exception as exc:
-            msg = "{msg} Error was: {error}".format(
-                msg=msg, error=to_native(exc)
-            )
+            msg = "{msg} Error was: {error}".format(msg=msg, error=to_native(exc))
             _raise_error(msg)
 
     if invert:
@@ -156,9 +154,7 @@ def index_of(
     elif isinstance(key, (string_types, integer_types, bool)):
 
         if not all(isinstance(entry, dict) for entry in data):
-            all_tipes = [
-                type(_to_well_known_type(entry)).__name__ for entry in data
-            ]
+            all_tipes = [type(_to_well_known_type(entry)).__name__ for entry in data]
             msg = (
                 "When a key name is provided, all list entries are required to "
                 "be dictionaries, got {str_tipes}"
@@ -172,9 +168,9 @@ def index_of(
                 if result:
                     res.append(idx)
             elif fail_on_missing:
-                msg = (
-                    "'{key}' was not found in '{dyct}' at [{index}]"
-                ).format(key=key, dyct=dyct, index=idx)
+                msg = ("'{key}' was not found in '{dyct}' at [{index}]").format(
+                    key=key, dyct=dyct, index=idx
+                )
                 errors.append(msg)
         if errors:
             _raise_error(

--- a/plugins/module_utils/common/to_paths.py
+++ b/plugins/module_utils/common/to_paths.py
@@ -9,13 +9,12 @@ flatten a complex object to dot bracket notation
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
-from ansible.module_utils.common._collections_compat import (
-    Mapping,
-    MutableMapping,
-)
+
+from ansible.module_utils.common._collections_compat import Mapping, MutableMapping
 
 
 def to_paths(var, prepend, wantlist):
@@ -43,9 +42,7 @@ def to_paths(var, prepend, wantlist):
         elif isinstance(data, list):
             if data:
                 for idx, val in enumerate(data):
-                    flatten(
-                        val, "{name}[{idx}]".format(name=name, idx=idx), out
-                    )
+                    flatten(val, "{name}[{idx}]".format(name=name, idx=idx), out)
             elif name:
                 out[name] = []
             else:

--- a/plugins/module_utils/common/utils.py
+++ b/plugins/module_utils/common/utils.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 from copy import deepcopy
@@ -21,9 +22,7 @@ def sort_list(val):
             if len(set(sorted_keys)) != 1:
                 raise ValueError("dictionaries do not match")
 
-            return sorted(
-                val, key=lambda d: tuple(d[k] for k in sorted_keys[0])
-            )
+            return sorted(val, key=lambda d: tuple(d[k] for k in sorted_keys[0]))
         return sorted(val)
     return val
 

--- a/plugins/modules/cli_parse.py
+++ b/plugins/modules/cli_parse.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/modules/fact_diff.py
+++ b/plugins/modules/fact_diff.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/modules/update_fact.py
+++ b/plugins/modules/update_fact.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/modules/validate.py
+++ b/plugins/modules/validate.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/plugin_utils/base/cli_parser.py
+++ b/plugins/plugin_utils/base/cli_parser.py
@@ -3,6 +3,7 @@ The base class for cli_parsers
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/plugin_utils/base/fact_diff.py
+++ b/plugins/plugin_utils/base/fact_diff.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/plugins/plugin_utils/base/ipaddr_utils.py
+++ b/plugins/plugin_utils/base/ipaddr_utils.py
@@ -9,12 +9,15 @@ The utils file for all ipaddr filters
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
-from ansible.utils.display import Display
 import types
+
 from ansible.errors import AnsibleFilterError
+from ansible.utils.display import Display
+
 
 try:
     import netaddr
@@ -263,9 +266,7 @@ def _peer_query(v, vtype):
             if int(v.ip) % 4 == 0:
                 raise AnsibleFilterError("Network address of /30 has no peer")
             if int(v.ip) % 4 == 3:
-                raise AnsibleFilterError(
-                    "Broadcast address of /30 has no peer"
-                )
+                raise AnsibleFilterError("Broadcast address of /30 has no peer")
             return str(netaddr.IPAddress(int(v.ip) ^ 3))
         raise AnsibleFilterError("Not a point-to-point network")
 
@@ -589,9 +590,7 @@ def ipaddr(value, query="", version=False, alias="ipaddr"):
                 return value
 
         except Exception:
-            raise AnsibleFilterError(
-                alias + ": unknown filter type: %s" % query
-            )
+            raise AnsibleFilterError(alias + ": unknown filter type: %s" % query)
 
     return False
 
@@ -601,8 +600,7 @@ def _need_netaddr(f_name, *args, **kwargs):
     verify python's netaddr for these filters to work
     """
     raise AnsibleFilterError(
-        "The %s filter requires python's netaddr be "
-        "installed on the ansible controller" % f_name
+        "The %s filter requires python's netaddr be " "installed on the ansible controller" % f_name
     )
 
 
@@ -710,9 +708,7 @@ def hwaddr(value, query="", alias="hwaddr"):
     except Exception:
         v = None
         if query and query != "bool":
-            raise AnsibleFilterError(
-                alias + ": not a hardware address: %s" % value
-            )
+            raise AnsibleFilterError(alias + ": not a hardware address: %s" % value)
 
     extras = []
     for arg in query_func_extra_args.get(query, tuple()):

--- a/plugins/plugin_utils/base/ipaddress_utils.py
+++ b/plugins/plugin_utils/base/ipaddress_utils.py
@@ -9,16 +9,20 @@ The utils file for all netaddr tests
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
+from functools import wraps
+
+from ansible import errors
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.six import ensure_text
-from functools import wraps
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
-from ansible import errors
+
 
 try:
     import ipaddress
@@ -71,9 +75,7 @@ def _is_subnet_of(network_a, network_b):
 def _validate_args(plugin, doc, params):
     """argspec validator utility function"""
 
-    valid, argspec_result, updated_params = check_argspec(
-        doc, plugin + " test", **params
-    )
+    valid, argspec_result, updated_params = check_argspec(doc, plugin + " test", **params)
 
     if not valid:
         raise AnsibleError(
@@ -86,6 +88,5 @@ def _validate_args(plugin, doc, params):
 
 def _need_netaddr(f_name, *args, **kwargs):
     raise errors.AnsibleFilterError(
-        "The %s filter requires python's netaddr be "
-        "installed on the ansible controller" % f_name
+        "The %s filter requires python's netaddr be " "installed on the ansible controller" % f_name
     )

--- a/plugins/plugin_utils/base/utils.py
+++ b/plugins/plugin_utils/base/utils.py
@@ -9,9 +9,11 @@ The utils file for all netaddr tests
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 from ansible.errors import AnsibleError
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
@@ -20,9 +22,7 @@ from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_valid
 def _validate_args(plugin, doc, params):
     """argspec validator utility function"""
 
-    valid, argspec_result, updated_params = check_argspec(
-        doc, plugin + " test", **params
-    )
+    valid, argspec_result, updated_params = check_argspec(doc, plugin + " test", **params)
 
     if not valid:
         raise AnsibleError(

--- a/plugins/plugin_utils/base/validate.py
+++ b/plugins/plugin_utils/base/validate.py
@@ -3,6 +3,7 @@ The base class for validator
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import os
@@ -10,16 +11,14 @@ import os
 from importlib import import_module
 
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_text, to_native
 
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import to_list
 
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    to_list,
-)
 
 try:
     import yaml
@@ -48,8 +47,10 @@ class ValidateBase(object):
         self._sub_plugin_options = {}
 
         cref = dict(zip(["corg", "cname", "plugin"], engine.split(".")))
-        validatorlib = "ansible_collections.{corg}.{cname}.plugins.sub_plugins.validate.{plugin}".format(
-            **cref
+        validatorlib = (
+            "ansible_collections.{corg}.{cname}.plugins.sub_plugins.validate.{plugin}".format(
+                **cref
+            )
         )
 
         validatordoc = getattr(import_module(validatorlib), "DOCUMENTATION")
@@ -140,9 +141,7 @@ class ValidateBase(object):
         return self._sub_plugin_options.get(name)
 
 
-def _load_validator(
-    engine, data, criteria, plugin_vars=None, cls_name="Validate", kwargs=None
-):
+def _load_validator(engine, data, criteria, plugin_vars=None, cls_name="Validate", kwargs=None):
     """
     Load the validate plugin from engine name
     :param engine: Name of the validate engine in format <org-name>.<collection-name>.<validate-plugin>
@@ -161,14 +160,12 @@ def _load_validator(
 
     if len(engine.split(".")) != 3:
         result["failed"] = True
-        result[
-            "msg"
-        ] = "Parser name should be provided as a full name including collection"
+        result["msg"] = "Parser name should be provided as a full name including collection"
         return None, result
 
     cref = dict(zip(["corg", "cname", "plugin"], engine.split(".")))
-    validatorlib = "ansible_collections.{corg}.{cname}.plugins.sub_plugins.validate.{plugin}".format(
-        **cref
+    validatorlib = (
+        "ansible_collections.{corg}.{cname}.plugins.sub_plugins.validate.{plugin}".format(**cref)
     )
 
     try:

--- a/plugins/plugin_utils/consolidate.py
+++ b/plugins/plugin_utils/consolidate.py
@@ -10,10 +10,12 @@ The consolidate plugin code
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
-from ansible.errors import AnsibleFilterError
 import itertools
+
+from ansible.errors import AnsibleFilterError
 
 
 def _raise_error(err):
@@ -27,9 +29,7 @@ def _raise_error(err):
         AnsibleFilterError: AnsibleError with filter name and message
     """
     tmp_err = []
-    tmplt_err = (
-        "Error when using plugin 'consolidate': '{filter}' reported {msg}"
-    )
+    tmplt_err = "Error when using plugin 'consolidate': '{filter}' reported {msg}"
     for filter in list(err.keys()):
         if err.get(filter):
             msg = ", ".join(err.get(filter))
@@ -69,9 +69,7 @@ def fail_on_filter(validator_func):
 
 
 @fail_on_filter
-def check_missing_match_key_duplicate(
-    data_sources, fail_missing_match_key, fail_duplicate
-):
+def check_missing_match_key_duplicate(data_sources, fail_missing_match_key, fail_duplicate):
     """Check if the match_key specified is present in all the supplied data,
     also check for duplicate data accross all the data sources
 
@@ -101,9 +99,7 @@ def check_missing_match_key_duplicate(
 
         if sorted(set(ds_values)) != sorted(ds_values) and fail_duplicate:
             errors_duplicate.append(
-                "duplicate values in data source {ds_idx}".format(
-                    ds_idx=ds_idx
-                )
+                "duplicate values in data source {ds_idx}".format(ds_idx=ds_idx)
             )
         results.append(set(ds_values))
     return results, {
@@ -153,9 +149,7 @@ def consolidate_facts(data_sources, all_values):
     for data_source in data_sources:
         match_key = data_source["match_key"]
         source = data_source["name"]
-        data_dict = {
-            d[match_key]: d for d in data_source["data"] if match_key in d
-        }
+        data_dict = {d[match_key]: d for d in data_source["data"] if match_key in d}
         for value in sorted(all_values):
             if value not in consolidated_facts:
                 consolidated_facts[value] = {}

--- a/plugins/plugin_utils/from_xml.py
+++ b/plugins/plugin_utils/from_xml.py
@@ -10,10 +10,13 @@ The from_xml plugin code
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import json
+
 from ansible.errors import AnsibleFilterError
+
 
 try:
     import xmltodict

--- a/plugins/plugin_utils/keep_keys.py
+++ b/plugins/plugin_utils/keep_keys.py
@@ -10,9 +10,11 @@ The keep_keys plugin code
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
+
 from ansible.errors import AnsibleFilterError
 
 
@@ -28,10 +30,7 @@ def _raise_error(msg):
 
 def keep_keys_from_dict_n_list(data, target, matching_parameter):
     if isinstance(data, list):
-        list_data = [
-            keep_keys_from_dict_n_list(each, target, matching_parameter)
-            for each in data
-        ]
+        list_data = [keep_keys_from_dict_n_list(each, target, matching_parameter) for each in data]
         return list_data
     if isinstance(data, dict):
         keep = {}
@@ -53,9 +52,7 @@ def keep_keys_from_dict_n_list(data, target, matching_parameter):
                         if k == key:
                             keep[k], match = val, True
                 else:
-                    list_data = keep_keys_from_dict_n_list(
-                        val, target, matching_parameter
-                    )
+                    list_data = keep_keys_from_dict_n_list(val, target, matching_parameter)
                     if isinstance(list_data, list) and not match:
                         list_data = [r for r in list_data if r not in ([], {})]
                         if all(isinstance(s, str) for s in list_data):

--- a/plugins/plugin_utils/remove_keys.py
+++ b/plugins/plugin_utils/remove_keys.py
@@ -10,9 +10,11 @@ The remove_keys plugin code
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
+
 from ansible.errors import AnsibleFilterError
 
 

--- a/plugins/plugin_utils/replace_keys.py
+++ b/plugins/plugin_utils/replace_keys.py
@@ -10,9 +10,11 @@ The replace_keys plugin code
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
+
 from ansible.errors import AnsibleFilterError
 
 

--- a/plugins/plugin_utils/to_xml.py
+++ b/plugins/plugin_utils/to_xml.py
@@ -10,9 +10,11 @@ The to_xml plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
+
 
 try:
     import xmltodict

--- a/plugins/sub_plugins/cli_parser/json_parser.py
+++ b/plugins/sub_plugins/cli_parser/json_parser.py
@@ -5,6 +5,7 @@ This is the json parser for use with the cli_parse module and action plugin
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -38,9 +39,8 @@ import json
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import string_types
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import (
-    CliParserBase,
-)
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 
 
 class CliParser(CliParserBase):

--- a/plugins/sub_plugins/cli_parser/textfsm_parser.py
+++ b/plugins/sub_plugins/cli_parser/textfsm_parser.py
@@ -6,6 +6,7 @@ https://github.com/google/textfsm
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -40,9 +41,9 @@ import os
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import (
-    CliParserBase,
-)
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
+
 
 try:
     import textfsm
@@ -94,9 +95,7 @@ class CliParser(CliParserBase):
         template_path = self._task_args.get("parser").get("template_path")
         if template_path and not os.path.isfile(template_path):
             return {
-                "errors": "error while reading template_path file {file}".format(
-                    file=template_path
-                )
+                "errors": "error while reading template_path file {file}".format(file=template_path)
             }
         try:
             template = open(self._task_args.get("parser").get("template_path"))

--- a/plugins/sub_plugins/cli_parser/ttp_parser.py
+++ b/plugins/sub_plugins/cli_parser/ttp_parser.py
@@ -6,6 +6,7 @@ https://github.com/dmulyalin/ttp
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -40,9 +41,9 @@ import os
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import (
-    CliParserBase,
-)
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
+
 
 try:
     from ttp import ttp
@@ -86,9 +87,7 @@ class CliParser(CliParserBase):
         or
         {"parsed": obj}
         """
-        cli_output = to_native(
-            self._task_args.get("text"), errors="surrogate_then_replace"
-        )
+        cli_output = to_native(self._task_args.get("text"), errors="surrogate_then_replace")
         res = self._check_reqs()
         if res.get("errors"):
             return {"errors": res.get("errors")}
@@ -99,26 +98,18 @@ class CliParser(CliParserBase):
         )
         if template_path and not os.path.isfile(template_path):
             return {
-                "errors": "error while reading template_path file {file}".format(
-                    file=template_path
-                )
+                "errors": "error while reading template_path file {file}".format(file=template_path)
             }
 
         try:
             parser_param = self._task_args.get("parser")
             vars = (
-                parser_param.get("vars", {}).get("ttp_vars", {})
-                if parser_param.get("vars")
-                else {}
+                parser_param.get("vars", {}).get("ttp_vars", {}) if parser_param.get("vars") else {}
             )
             kwargs = (
-                parser_param.get("vars", {}).get("ttp_init", {})
-                if parser_param.get("vars")
-                else {}
+                parser_param.get("vars", {}).get("ttp_init", {}) if parser_param.get("vars") else {}
             )
-            parser = ttp(
-                data=cli_output, template=template_path, vars=vars, **kwargs
-            )
+            parser = ttp(data=cli_output, template=template_path, vars=vars, **kwargs)
             parser.parse(one=True)
             ttp_results = (
                 parser_param.get("vars", {}).get("ttp_results", {})

--- a/plugins/sub_plugins/cli_parser/xml_parser.py
+++ b/plugins/sub_plugins/cli_parser/xml_parser.py
@@ -6,6 +6,7 @@ https://github.com/martinblech/xmltodict
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -38,9 +39,8 @@ EXAMPLES = r"""
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import (
-    CliParserBase,
-)
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.cli_parser import CliParserBase
 
 
 try:
@@ -87,9 +87,9 @@ class CliParser(CliParserBase):
 
         cli_output = self._task_args.get("text")
 
-        network_os = self._task_args.get("parser").get(
-            "os"
-        ) or self._task_vars.get("ansible_network_os")
+        network_os = self._task_args.get("parser").get("os") or self._task_vars.get(
+            "ansible_network_os"
+        )
         # the nxos | xml includes a odd garbage line at the end, so remove it
         if not network_os:
             self._debug("network_os value is not set")

--- a/plugins/sub_plugins/fact_diff/native.py
+++ b/plugins/sub_plugins/fact_diff/native.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -28,10 +29,10 @@ EXAMPLES = r"""
 """
 
 import re
+
 from ansible.plugins.callback import CallbackBase
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.fact_diff import (
-    FactDiffBase,
-)
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.fact_diff import FactDiffBase
 
 
 class FactDiff(FactDiffBase):
@@ -58,16 +59,12 @@ class FactDiff(FactDiffBase):
             self._before = [
                 line
                 for line in self._before
-                if not any(
-                    regex.match(str(line)) for regex in self._skip_lines
-                )
+                if not any(regex.match(str(line)) for regex in self._skip_lines)
             ]
             self._after = [
                 line
                 for line in self._after
-                if not any(
-                    regex.match(str(line)) for regex in self._skip_lines
-                )
+                if not any(regex.match(str(line)) for regex in self._skip_lines)
             ]
         if isinstance(self._before, list):
             self._debug("'before' is a list, joining with \n")
@@ -85,7 +82,5 @@ class FactDiff(FactDiffBase):
         if self._errors:
             return {"errors": " ".join(self._errors)}
         self._xform()
-        diff = CallbackBase()._get_diff(
-            {"before": self._before, "after": self._after}
-        )
+        diff = CallbackBase()._get_diff({"before": self._before, "after": self._after})
         return {"diff": diff}

--- a/plugins/sub_plugins/validate/config.py
+++ b/plugins/sub_plugins/validate/config.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -47,17 +48,13 @@ EXAMPLES = r"""
 
 import re
 
-from ansible.module_utils._text import to_text
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    ValidateBase,
-)
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import to_list
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import ValidateBase
 
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    to_list,
-)
 
 try:
     import yaml
@@ -90,9 +87,7 @@ class Validate(ValidateBase):
 
         try:
             if isinstance(self._criteria, string_types):
-                self._criteria = yaml.load(
-                    str(self._criteria), Loader=SafeLoader
-                )
+                self._criteria = yaml.load(str(self._criteria), Loader=SafeLoader)
         except yaml.parser.ParserError as exc:
             msg = (
                 "'criteria' option value is invalid, value should be valid YAML."
@@ -105,31 +100,21 @@ class Validate(ValidateBase):
         issues = []
         for item in to_list(self._criteria):
             if "name" not in item:
-                issues.append(
-                    'Criteria {item} missing "name" key'.format(item=item)
-                )
+                issues.append('Criteria {item} missing "name" key'.format(item=item))
             if "action" not in item:
-                issues.append(
-                    'Criteria {item} missing "action" key'.format(item=item)
-                )
+                issues.append('Criteria {item} missing "action" key'.format(item=item))
             elif item["action"] not in ("warn", "fail"):
                 issues.append(
-                    'Action in criteria {item} is not one of "warn" or "fail"'.format(
-                        item=item
-                    )
+                    'Action in criteria {item} is not one of "warn" or "fail"'.format(item=item)
                 )
             if "rule" not in item:
-                issues.append(
-                    'Criteria {item} missing "rule" key'.format(item=item)
-                )
+                issues.append('Criteria {item} missing "rule" key'.format(item=item))
             else:
                 try:
                     item["rule"] = re.compile(item["rule"])
                 except re.error as exc:
                     issues.append(
-                        'Failed to compile regex "{rule}": {exc}'.format(
-                            rule=item["rule"], exc=exc
-                        )
+                        'Failed to compile regex "{rule}": {exc}'.format(rule=item["rule"], exc=exc)
                     )
 
         if issues:
@@ -168,16 +153,10 @@ class Validate(ValidateBase):
                 match = criteria["rule"].search(line)
                 if match:
                     if criteria["action"] == "warn":
-                        warnings.append(
-                            format_message(match, line_number, criteria)
-                        )
+                        warnings.append(format_message(match, line_number, criteria))
                     if criteria["action"] == "fail":
-                        errors.append(
-                            {"message": criteria["name"], "found": line}
-                        )
-                        error_messages.append(
-                            format_message(match, line_number, criteria)
-                        )
+                        errors.append({"message": criteria["name"], "found": line})
+                        error_messages.append(format_message(match, line_number, criteria))
 
         if errors:
             if "errors" not in self._result:

--- a/plugins/sub_plugins/validate/jsonschema.py
+++ b/plugins/sub_plugins/validate/jsonschema.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -40,18 +41,14 @@ DOCUMENTATION = """
 
 import json
 
+from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import missing_required_lib
-from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    ValidateBase,
-)
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import to_list
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import ValidateBase
 
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    to_list,
-)
 
 # PY2 compatibility for JSONDecodeError
 try:
@@ -176,40 +173,28 @@ class Validate(ValidateBase):
                     criteria, format_checker=jsonschema.draft7_format_checker
                 )
 
-            validation_errors = sorted(
-                validator.iter_errors(self._data), key=lambda e: e.path
-            )
+            validation_errors = sorted(validator.iter_errors(self._data), key=lambda e: e.path)
 
             if validation_errors:
                 if "errors" not in self._result:
                     self._result["errors"] = []
 
                 for validation_error in validation_errors:
-                    if isinstance(
-                        validation_error, jsonschema.ValidationError
-                    ):
+                    if isinstance(validation_error, jsonschema.ValidationError):
                         error = {
                             "message": validation_error.message,
-                            "data_path": to_path(
-                                validation_error.absolute_path
-                            ),
-                            "json_path": json_path(
-                                validation_error.absolute_path
-                            ),
-                            "schema_path": to_path(
-                                validation_error.relative_schema_path
-                            ),
+                            "data_path": to_path(validation_error.absolute_path),
+                            "json_path": json_path(validation_error.absolute_path),
+                            "schema_path": to_path(validation_error.relative_schema_path),
                             "relative_schema": validation_error.schema,
                             "expected": validation_error.validator_value,
                             "validator": validation_error.validator,
                             "found": validation_error.instance,
                         }
                         self._result["errors"].append(error)
-                        error_message = (
-                            "At '{schema_path}' {message}. ".format(
-                                schema_path=error["schema_path"],
-                                message=error["message"],
-                            )
+                        error_message = "At '{schema_path}' {message}. ".format(
+                            schema_path=error["schema_path"],
+                            message=error["message"],
                         )
                         error_messages.append(error_message)
         if error_messages:

--- a/plugins/test/in_any_network.py
+++ b/plugins/test/in_any_network.py
@@ -8,12 +8,10 @@ Test plugin file for netaddr tests: in_any_network
 """
 
 from __future__ import absolute_import, division, print_function
-from ansible_collections.ansible.utils.plugins.test.in_network import (
-    _in_network,
-)
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+from ansible_collections.ansible.utils.plugins.test.in_network import _in_network
+
 
 __metaclass__ = type
 

--- a/plugins/test/in_network.py
+++ b/plugins/test/in_network.py
@@ -8,14 +8,14 @@ Test plugin file for netaddr tests: in_network
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _is_subnet_of,
     _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/in_one_network.py
+++ b/plugins/test/in_one_network.py
@@ -8,12 +8,11 @@ Test plugin file for netaddr tests: in_one_network
 """
 
 from __future__ import absolute_import, division, print_function
-from ansible_collections.ansible.utils.plugins.test.in_network import (
-    _in_network,
-)
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
     _validate_args,
 )
+from ansible_collections.ansible.utils.plugins.test.in_network import _in_network
 
 
 __metaclass__ = type

--- a/plugins/test/ip.py
+++ b/plugins/test/ip.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ip
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ip_address.py
+++ b/plugins/test/ip_address.py
@@ -8,13 +8,12 @@ Test plugin file for netaddr tests: ip_address
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
 
 
 __metaclass__ = type

--- a/plugins/test/ipv4.py
+++ b/plugins/test/ipv4.py
@@ -8,11 +8,13 @@ Test plugin file for netaddr tests: ipv4
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _need_ipaddress,
     _validate_args,
+    ip_network,
 )
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv4_address.py
+++ b/plugins/test/ipv4_address.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv4_address
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv4_hostmask.py
+++ b/plugins/test/ipv4_hostmask.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv4_hostmask
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv4_netmask.py
+++ b/plugins/test/ipv4_netmask.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv4_netmask
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv6.py
+++ b/plugins/test/ipv6.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv6
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
     _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv6_address.py
+++ b/plugins/test/ipv6_address.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv6_address
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv6_ipv4_mapped.py
+++ b/plugins/test/ipv6_ipv4_mapped.py
@@ -8,11 +8,13 @@ Test plugin file for netaddr tests: ipv6_ipv4_mapped
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
     _validate_args,
+    ip_address,
 )
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv6_sixtofour.py
+++ b/plugins/test/ipv6_sixtofour.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv6_sixtofour
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/ipv6_teredo.py
+++ b/plugins/test/ipv6_teredo.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: ipv6_teredo
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/loopback.py
+++ b/plugins/test/loopback.py
@@ -8,11 +8,13 @@ Test plugin file for netaddr tests: loopback
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
     _validate_args,
+    ip_address,
 )
+
 
 __metaclass__ = type
 

--- a/plugins/test/mac.py
+++ b/plugins/test/mac.py
@@ -8,10 +8,11 @@ Test plugin file for netaddr tests: mac
 """
 
 from __future__ import absolute_import, division, print_function
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+
 import re
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/multicast.py
+++ b/plugins/test/multicast.py
@@ -8,13 +8,12 @@ Test plugin file for netaddr tests: multicast
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
 
 
 __metaclass__ = type

--- a/plugins/test/private.py
+++ b/plugins/test/private.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: private
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/public.py
+++ b/plugins/test/public.py
@@ -8,11 +8,13 @@ Test plugin file for netaddr tests: public
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
     _validate_args,
+    ip_address,
 )
+
 
 __metaclass__ = type
 

--- a/plugins/test/reserved.py
+++ b/plugins/test/reserved.py
@@ -8,13 +8,13 @@ Test plugin file for netaddr tests: reserved
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
+    ip_address,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/resolvable.py
+++ b/plugins/test/resolvable.py
@@ -7,14 +7,14 @@
 Test plugin file for netaddr tests: resolvable
 """
 from __future__ import absolute_import, division, print_function
+
+import socket
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
     _need_ipaddress,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
 
-import socket
 
 try:
     import ipaddress

--- a/plugins/test/subnet_of.py
+++ b/plugins/test/subnet_of.py
@@ -8,12 +8,14 @@ Test plugin file for netaddr tests: subnet_of
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
-    _need_ipaddress,
     _is_subnet_of,
+    _need_ipaddress,
     _validate_args,
+    ip_network,
 )
+
 
 __metaclass__ = type
 

--- a/plugins/test/supernet_of.py
+++ b/plugins/test/supernet_of.py
@@ -8,14 +8,14 @@ Test plugin file for netaddr tests: supernet_of
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_network,
-    _need_ipaddress,
     _is_subnet_of,
+    _need_ipaddress,
+    ip_network,
 )
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import (
-    _validate_args,
-)
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.utils import _validate_args
+
 
 __metaclass__ = type
 

--- a/plugins/test/unspecified.py
+++ b/plugins/test/unspecified.py
@@ -8,11 +8,13 @@ Test plugin file for netaddr tests: unspecified
 """
 
 from __future__ import absolute_import, division, print_function
+
 from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddress_utils import (
-    ip_address,
     _need_ipaddress,
     _validate_args,
+    ip_address,
 )
+
 
 __metaclass__ = type
 

--- a/plugins/test/validate.py
+++ b/plugins/test/validate.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 DOCUMENTATION = """
     name: validate
@@ -74,15 +75,13 @@ RETURN = """
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    _load_validator,
-)
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    to_list,
-)
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     check_argspec,
 )
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import to_list
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import _load_validator
+
 
 ARGSPEC_CONDITIONALS = {}
 
@@ -101,10 +100,7 @@ def validate(*args, **kwargs):
             params.update({item: kwargs[item]})
 
     valid, argspec_result, updated_params = check_argspec(
-        DOCUMENTATION,
-        "validate test",
-        schema_conditionals=ARGSPEC_CONDITIONALS,
-        **params
+        DOCUMENTATION, "validate test", schema_conditionals=ARGSPEC_CONDITIONALS, **params
     )
     if not valid:
         raise AnsibleError(
@@ -122,8 +118,7 @@ def validate(*args, **kwargs):
     )
     if validator_result.get("failed"):
         raise AnsibleError(
-            "validate lookup plugin failed with errors: %s"
-            % validator_result.get("msg")
+            "validate lookup plugin failed with errors: %s" % validator_result.get("msg")
         )
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 79
+line-length = 100
 
 [tool.pytest.ini_options]
 addopts = [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import subprocess
@@ -39,9 +40,7 @@ def run(localhost_project, environment):
         print(process.stdout.decode("utf-8"))
         print(process.stderr.decode("utf-8"))
 
-        pytest.fail(
-            reason=f"Integration test failed: {localhost_project.role}"
-        )
+        pytest.fail(reason=f"Integration test failed: {localhost_project.role}")
 
 
 def test_integration(localhost_project, environment, monkeypatch):

--- a/tests/unit/compat/builtins.py
+++ b/tests/unit/compat/builtins.py
@@ -18,6 +18,7 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 #

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -18,13 +18,16 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 """
 Compat module for Python3.x's unittest.mock module
 """
-import _io  # pyright: ignore[reportMissingImports]
 import sys
+
+import _io  # pyright: ignore[reportMissingImports]
+
 
 # Python 2.7
 
@@ -102,9 +105,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
         global file_spec
         if file_spec is None:
 
-            file_spec = list(
-                set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO)))
-            )
+            file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
 
         if mock is None:
             mock = MagicMock(name="open", spec=open)  # noqa F405

--- a/tests/unit/compat/unittest.py
+++ b/tests/unit/compat/unittest.py
@@ -18,6 +18,7 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 """
@@ -25,6 +26,7 @@ Compat module for Python2.7's unittest module
 """
 
 import sys
+
 
 # Allow wildcard import because we really do want to import all of
 # unittests's symbols into this compat shim

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -18,13 +18,14 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import os
 
 from ansible.errors import AnsibleParserError
-from ansible.parsing.dataloader import DataLoader
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.parsing.dataloader import DataLoader
 
 
 class DictDataLoader(DataLoader):

--- a/tests/unit/mock/path.py
+++ b/tests/unit/mock/path.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
-from ansible_collections.ansible.netcommon.tests.unit.compat.mock import (
-    MagicMock,
-)
 from ansible.utils.path import unfrackpath
+from ansible_collections.ansible.netcommon.tests.unit.compat.mock import MagicMock
 
 
-mock_unfrackpath_noop = MagicMock(
-    spec_set=unfrackpath, side_effect=lambda x, *args, **kwargs: x
-)
+mock_unfrackpath_noop = MagicMock(spec_set=unfrackpath, side_effect=lambda x, *args, **kwargs: x)

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -19,16 +19,18 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
-import sys
 import json
+import sys
 
 from contextlib import contextmanager
 from io import BytesIO, StringIO
-from ansible_collections.ansible.netcommon.tests.unit.compat import unittest
-from ansible.module_utils.six import PY3
+
 from ansible.module_utils._text import to_bytes
+from ansible.module_utils.six import PY3
+from ansible_collections.ansible.netcommon.tests.unit.compat import unittest
 
 
 @contextmanager

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -14,10 +14,10 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 from ansible.module_utils._text import to_bytes
-
 from ansible.parsing.vault import VaultSecret
 
 
@@ -37,6 +37,4 @@ class TextVaultSecret(VaultSecret):
     @property
     def bytes(self):
         """The text encoded with encoding, unless we specifically set _bytes."""
-        return self._bytes or to_bytes(
-            self.text, encoding=self.encoding, errors=self.errors
-        )
+        return self._bytes or to_bytes(self.text, encoding=self.encoding, errors=self.errors)

--- a/tests/unit/mock/yaml_helper.py
+++ b/tests/unit/mock/yaml_helper.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 import io
+
 import yaml
 
 from ansible.module_utils.six import PY3
-from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.parsing.yaml.dumper import AnsibleDumper
+from ansible.parsing.yaml.loader import AnsibleLoader
 
 
 class YamlTestUtils(object):
@@ -44,9 +46,7 @@ class YamlTestUtils(object):
         obj_2 = loader.get_data()
 
         # dump the gen 2 objects directory to strings
-        string_from_object_dump_2 = self._dump_string(
-            obj_2, dumper=AnsibleDumper
-        )
+        string_from_object_dump_2 = self._dump_string(obj_2, dumper=AnsibleDumper)
 
         # The gen 1 and gen 2 yaml strings
         self.assertEqual(string_from_object_dump, string_from_object_dump_2)
@@ -58,9 +58,7 @@ class YamlTestUtils(object):
         loader_3 = self._loader(stream_3)
         obj_3 = loader_3.get_data()
 
-        string_from_object_dump_3 = self._dump_string(
-            obj_3, dumper=AnsibleDumper
-        )
+        string_from_object_dump_3 = self._dump_string(obj_3, dumper=AnsibleDumper)
 
         self.assertEqual(obj, obj_3)
         # should be transitive, but...
@@ -92,12 +90,8 @@ class YamlTestUtils(object):
         stream_obj_from_string = io.StringIO()
 
         if PY3:
-            yaml.dump(
-                obj_from_stream, stream_obj_from_stream, Dumper=AnsibleDumper
-            )
-            yaml.dump(
-                obj_from_stream, stream_obj_from_string, Dumper=AnsibleDumper
-            )
+            yaml.dump(obj_from_stream, stream_obj_from_stream, Dumper=AnsibleDumper)
+            yaml.dump(obj_from_stream, stream_obj_from_string, Dumper=AnsibleDumper)
         else:
             yaml.dump(
                 obj_from_stream,
@@ -119,12 +113,8 @@ class YamlTestUtils(object):
         stream_obj_from_string.seek(0)
 
         if PY3:
-            yaml_string_obj_from_stream = yaml.dump(
-                obj_from_stream, Dumper=AnsibleDumper
-            )
-            yaml_string_obj_from_string = yaml.dump(
-                obj_from_string, Dumper=AnsibleDumper
-            )
+            yaml_string_obj_from_stream = yaml.dump(obj_from_stream, Dumper=AnsibleDumper)
+            yaml_string_obj_from_string = yaml.dump(obj_from_string, Dumper=AnsibleDumper)
         else:
             yaml_string_obj_from_stream = yaml.dump(
                 obj_from_stream, Dumper=AnsibleDumper, encoding=None
@@ -134,11 +124,7 @@ class YamlTestUtils(object):
             )
 
         assert yaml_string == yaml_string_obj_from_stream
-        assert (
-            yaml_string
-            == yaml_string_obj_from_stream
-            == yaml_string_obj_from_string
-        )
+        assert yaml_string == yaml_string_obj_from_stream == yaml_string_obj_from_string
         assert (
             yaml_string
             == yaml_string_obj_from_stream

--- a/tests/unit/module_utils/test_argspec_validate.py
+++ b/tests/unit/module_utils/test_argspec_validate.py
@@ -6,12 +6,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+
 from .fixtures.docstring import DOCUMENTATION
 
 
@@ -98,16 +101,12 @@ class TestSortList(unittest.TestCase):
             data=data,
             schema=DOCUMENTATION,
             schema_format="doc",
-            schema_conditionals={
-                "required_together": [["param_str", "param_bool"]]
-            },
+            schema_conditionals={"required_together": [["param_str", "param_bool"]]},
             name="test_action",
         )
         valid, errors, _updated_data = aav.validate()
         self.assertFalse(valid)
-        self.assertIn(
-            "parameters are required together: param_str, param_bool", errors
-        )
+        self.assertIn("parameters are required together: param_str, param_bool", errors)
 
     def test_unsupported_param(self):
         data = {"param_str": "string", "not_valid": "string"}
@@ -122,9 +121,7 @@ class TestSortList(unittest.TestCase):
         self.assertFalse(valid)
         if isinstance(errors, list):
             # for ansibleargspecvalidator 2.11 its returning errors as list
-            self.assertIn(
-                "not_valid. Supported parameters include:", errors[0]
-            )
+            self.assertIn("not_valid. Supported parameters include:", errors[0])
         else:
             self.assertIn(
                 "Unsupported parameters for 'test_action' module: not_valid",

--- a/tests/unit/module_utils/test_dict_merge.py
+++ b/tests/unit/module_utils/test_dict_merge.py
@@ -6,12 +6,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    dict_merge,
-)
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import dict_merge
 
 
 class TestDict_merge(unittest.TestCase):

--- a/tests/unit/module_utils/test_get_path.py
+++ b/tests/unit/module_utils/test_get_path.py
@@ -6,15 +6,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import (
-    get_path,
-)
-
 
 from ansible.template import Templar
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import get_path
 
 
 class TestGetPath(unittest.TestCase):
@@ -24,18 +23,14 @@ class TestGetPath(unittest.TestCase):
     def test_get_path_pass(self):
         var = {"a": {"b": {"c": {"d": [0, 1]}}}}
         path = "a.b.c.d[0]"
-        result = get_path(
-            var, path, environment=self._environment, wantlist=False
-        )
+        result = get_path(var, path, environment=self._environment, wantlist=False)
         expected = "0"
         self.assertEqual(result, expected)
 
     def test_get_path_pass_wantlist(self):
         var = {"a": {"b": {"c": {"d": [0, 1]}}}}
         path = "a.b.c.d[0]"
-        result = get_path(
-            var, path, environment=self._environment, wantlist=True
-        )
+        result = get_path(var, path, environment=self._environment, wantlist=True)
         expected = ["0"]
         self.assertEqual(result, expected)
 

--- a/tests/unit/module_utils/test_index_of.py
+++ b/tests/unit/module_utils/test_index_of.py
@@ -6,14 +6,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import unittest
-from ansible_collections.ansible.utils.plugins.module_utils.common.index_of import (
-    index_of,
-)
+
 from ansible.template import Templar
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.index_of import index_of
 
 
 class TestIndexOfFilter(unittest.TestCase):
@@ -45,9 +46,7 @@ class TestIndexOfFilter(unittest.TestCase):
     def test_fail_on_missing(self):
         obj, test, value, key = [{"a": True}, {"c": False}], "==", True, "a"
         with self.assertRaises(Exception) as exc:
-            index_of(
-                obj, test, value, key, fail_on_missing=True, tests=self._tests
-            )
+            index_of(obj, test, value, key, fail_on_missing=True, tests=self._tests)
         self.assertIn("'a' was not found", str(exc.exception))
 
     def test_just_test(self):

--- a/tests/unit/module_utils/test_sort_list.py
+++ b/tests/unit/module_utils/test_sort_list.py
@@ -6,12 +6,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.module_utils.common.utils import (
-    sort_list,
-)
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.utils import sort_list
 
 
 class TestSortList(unittest.TestCase):

--- a/tests/unit/module_utils/test_to_paths.py
+++ b/tests/unit/module_utils/test_to_paths.py
@@ -6,20 +6,18 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
-import json
 import heapq
+import json
 import os
 import unittest
-from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import (
-    get_path,
-)
-from ansible_collections.ansible.utils.plugins.module_utils.common.to_paths import (
-    to_paths,
-)
 
 from ansible.template import Templar
+
+from ansible_collections.ansible.utils.plugins.module_utils.common.get_path import get_path
+from ansible_collections.ansible.utils.plugins.module_utils.common.to_paths import to_paths
 
 
 class TestToPaths(unittest.TestCase):
@@ -52,18 +50,14 @@ class TestToPaths(unittest.TestCase):
 
     def test_roundtrip_large(self):
         """Test the 1000 longest keys, otherwise this takes a _really_ long time"""
-        big_json_path = os.path.join(
-            os.path.dirname(__file__), "fixtures", "large.json"
-        )
+        big_json_path = os.path.join(os.path.dirname(__file__), "fixtures", "large.json")
         with open(big_json_path) as fhand:
             big_json = fhand.read()
         var = json.loads(big_json)
         paths = to_paths(var, prepend=None, wantlist=None)
         to_tests = heapq.nlargest(1000, list(paths.keys()), key=len)
         for to_test in to_tests:
-            gotten = get_path(
-                var, to_test, environment=self._environment, wantlist=False
-            )
+            gotten = get_path(var, to_test, environment=self._environment, wantlist=False)
             self.assertEqual(gotten, paths[to_test])
 
     def test_to_paths_empty_list(self):

--- a/tests/unit/plugins/action/test_fact_diff.py
+++ b/tests/unit/plugins/action/test_fact_diff.py
@@ -5,16 +5,17 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import re
 import unittest
+
 from ansible.playbook.task import Task
 from ansible.template import Templar
 
-from ansible_collections.ansible.utils.plugins.action.fact_diff import (
-    ActionModule,
-)
+from ansible_collections.ansible.utils.plugins.action.fact_diff import ActionModule
+
 
 try:
     from unittest.mock import MagicMock  # pylint:disable=syntax-error
@@ -154,15 +155,9 @@ class TestUpdate_Fact(unittest.TestCase):
         self._plugin._task.args = {"before": before, "after": after}
         result = self._plugin.run(task_vars=self._task_vars)
         self.assertTrue(result["changed"])
-        mlines = [
-            line for line in result["diff_lines"] if re.match(r"^-\s+3$", line)
-        ]
+        mlines = [line for line in result["diff_lines"] if re.match(r"^-\s+3$", line)]
         self.assertEqual(1, len(mlines))
-        mlines = [
-            line
-            for line in result["diff_lines"]
-            if re.match(r"^\+\s+4$", line)
-        ]
+        mlines = [line for line in result["diff_lines"] if re.match(r"^\+\s+4$", line)]
         self.assertEqual(1, len(mlines))
 
     def test_invalid_diff_engine_not_collection(self):

--- a/tests/unit/plugins/action/test_update_fact.py
+++ b/tests/unit/plugins/action/test_update_fact.py
@@ -5,17 +5,18 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import copy
 import unittest
-from jinja2 import Template, TemplateSyntaxError
+
 from ansible.playbook.task import Task
 from ansible.template import Templar
+from jinja2 import Template, TemplateSyntaxError
 
-from ansible_collections.ansible.utils.plugins.action.update_fact import (
-    ActionModule,
-)
+from ansible_collections.ansible.utils.plugins.action.update_fact import ActionModule
+
 
 try:
     from unittest.mock import MagicMock  # pylint:disable=syntax-error
@@ -104,18 +105,14 @@ class TestUpdate_Fact(unittest.TestCase):
         self._plugin._task.args = {"a": 10}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars=None)
-        self.assertIn(
-            "missing required arguments: updates", str(error.exception)
-        )
+        self.assertIn("missing required arguments: updates", str(error.exception))
 
     def test_argspec_none(self):
         """Check passing a dict"""
         self._plugin._task.args = {}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars=None)
-        self.assertIn(
-            "missing required arguments: updates", str(error.exception)
-        )
+        self.assertIn("missing required arguments: updates", str(error.exception))
 
     def test_valid_jinja(self):
         for test in VALID_TESTS:
@@ -140,9 +137,7 @@ class TestUpdate_Fact(unittest.TestCase):
         self._plugin._task.args = {"updates": [{"path": "a.b.c", "value": 5}]}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars={"vars": {}})
-        self.assertIn(
-            "'a' was not found in the current facts.", str(error.exception)
-        )
+        self.assertIn("'a' was not found in the current facts.", str(error.exception))
 
     def test_run_simple(self):
         """Confirm a valid argspec passes"""
@@ -156,9 +151,7 @@ class TestUpdate_Fact(unittest.TestCase):
 
     def test_run_multiple(self):
         """Confirm multiple paths passes"""
-        task_vars = {
-            "vars": {"a": {"b1": [1, 2, 3], "b2": {"c": "123", "d": False}}}
-        }
+        task_vars = {"vars": {"a": {"b1": [1, 2, 3], "b2": {"c": "123", "d": False}}}}
         expected = {"a": {"b1": [1, 2, 3, 4], "b2": {"c": 456, "d": True}}}
         expected.update({"changed": True})
         self._plugin._task.args = {
@@ -197,9 +190,7 @@ class TestUpdate_Fact(unittest.TestCase):
         expected = copy.deepcopy(task_vars["vars"])
         expected["a"]["b"].append(4)
         expected.update({"changed": True})
-        self._plugin._task.args = {
-            "updates": [{"path": "a['b'][3]", "value": 4}]
-        }
+        self._plugin._task.args = {"updates": [{"path": "a['b'][3]", "value": 4}]}
         result = self._plugin.run(task_vars=task_vars)
         self.assertEqual(result, expected)
 
@@ -209,9 +200,7 @@ class TestUpdate_Fact(unittest.TestCase):
         expected = copy.deepcopy(task_vars["vars"])
         expected["a"]["b"].append(4)
         expected.update({"changed": True})
-        self._plugin._task.args = {
-            "updates": [{"path": 'a["b"][3]', "value": 4}]
-        }
+        self._plugin._task.args = {"updates": [{"path": 'a["b"][3]', "value": 4}]}
         result = self._plugin.run(task_vars=task_vars)
         self.assertEqual(result, expected)
 
@@ -231,9 +220,7 @@ class TestUpdate_Fact(unittest.TestCase):
         expected = copy.deepcopy(task_vars["vars"])
         expected["a"]["0"][0] = 0
         expected.update({"changed": True})
-        self._plugin._task.args = {
-            "updates": [{"path": 'a["0"].0', "value": 0}]
-        }
+        self._plugin._task.args = {"updates": [{"path": 'a["0"].0', "value": 0}]}
         result = self._plugin.run(task_vars=task_vars)
         self.assertEqual(result, expected)
 
@@ -246,9 +233,7 @@ class TestUpdate_Fact(unittest.TestCase):
 
     def test_run_invalid_path_bracket_after_dot(self):
         """Invalid path format"""
-        self._plugin._task.args = {
-            "updates": [{"path": "a.['b']", "value": 0}]
-        }
+        self._plugin._task.args = {"updates": [{"path": "a.['b']", "value": 0}]}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars={"vars": {}})
         self.assertIn("malformed", str(error.exception))
@@ -276,9 +261,7 @@ class TestUpdate_Fact(unittest.TestCase):
         expected = copy.deepcopy(task_vars["vars"])
         expected["a"]["b"] = [1, 2, 3]
         expected.update({"changed": False})
-        self._plugin._task.args = {
-            "updates": [{"path": "a.b", "value": [1, 2, 3]}]
-        }
+        self._plugin._task.args = {"updates": [{"path": "a.b", "value": [1, 2, 3]}]}
         result = self._plugin.run(task_vars=task_vars)
         self.assertEqual(result, expected)
 
@@ -293,14 +276,10 @@ class TestUpdate_Fact(unittest.TestCase):
     def test_run_list_not_int(self):
         """Confirm error when key not found"""
         task_vars = {"vars": {"a": {"b": [1]}}}
-        self._plugin._task.args = {
-            "updates": [{"path": "a.b['0']", "value": 2}]
-        }
+        self._plugin._task.args = {"updates": [{"path": "a.b['0']", "value": 2}]}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars=task_vars)
-        self.assertIn(
-            "index provided was not an integer", str(error.exception)
-        )
+        self.assertIn("index provided was not an integer", str(error.exception))
 
     def test_run_list_not_long(self):
         """List not long enough"""
@@ -308,9 +287,7 @@ class TestUpdate_Fact(unittest.TestCase):
         self._plugin._task.args = {"updates": [{"path": "a.b.2", "value": 2}]}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars=task_vars)
-        self.assertIn(
-            "not long enough for item #2 to be set", str(error.exception)
-        )
+        self.assertIn("not long enough for item #2 to be set", str(error.exception))
 
     def test_not_mutable_sequence_or_mapping(self):
         """Confirm graceful fail when immutable object
@@ -349,9 +326,7 @@ class TestUpdate_Fact(unittest.TestCase):
         self._plugin._task.args = {"updates": [{"path": "123", "value": 1}]}
         with self.assertRaises(Exception) as error:
             self._plugin.run(task_vars=task_vars)
-        self.assertIn(
-            "'123' was not found in the current facts", str(error.exception)
-        )
+        self.assertIn("'123' was not found in the current facts", str(error.exception))
 
     def test_run_not_dotted_success_same(self):
         """Test with a not dotted key, no change"""
@@ -368,8 +343,6 @@ class TestUpdate_Fact(unittest.TestCase):
         expected = copy.deepcopy(task_vars["vars"])
         expected["a"]["True"] = 1
         expected.update({"changed": True})
-        self._plugin._task.args = {
-            "updates": [{"path": "a['True']", "value": 1}]
-        }
+        self._plugin._task.args = {"updates": [{"path": "a['True']", "value": 1}]}
         result = self._plugin.run(task_vars=task_vars)
         self.assertEqual(result, expected)

--- a/tests/unit/plugins/action/test_validate.py
+++ b/tests/unit/plugins/action/test_validate.py
@@ -5,16 +5,17 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
+from ansible.errors import AnsibleActionFail
 from ansible.playbook.task import Task
 from ansible.template import Templar
-from ansible.errors import AnsibleActionFail
 
-from ansible_collections.ansible.utils.plugins.action.validate import (
-    ActionModule,
-)
+from ansible_collections.ansible.utils.plugins.action.validate import ActionModule
+
 
 try:
     from unittest.mock import MagicMock  # pylint:disable=syntax-error
@@ -61,11 +62,7 @@ CRITERIA_CRC_ERROR_CHECK = {
         "^.*": {
             "type": "object",
             "properties": {
-                "counters": {
-                    "properties": {
-                        "in_crc_errors": {"type": "number", "maximum": 0}
-                    }
-                }
+                "counters": {"properties": {"in_crc_errors": {"type": "number", "maximum": 0}}}
             },
         }
     },
@@ -73,9 +70,7 @@ CRITERIA_CRC_ERROR_CHECK = {
 
 CRITERIA_ENABLED_CHECK = {
     "type": "object",
-    "patternProperties": {
-        "^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}
-    },
+    "patternProperties": {"^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}},
 }
 
 CRITERIA_OPER_STATUS_UP_CHECK = {
@@ -96,11 +91,7 @@ CRITERIA_IN_RATE_CHECK = {
             "properties": {
                 "counters": {
                     "properties": {
-                        "rate": {
-                            "properties": {
-                                "in_rate": {"type": "number", "maximum": 0}
-                            }
-                        }
+                        "rate": {"properties": {"in_rate": {"type": "number", "maximum": 0}}}
                     }
                 }
             },
@@ -182,9 +173,7 @@ class TestValidate(unittest.TestCase):
 
         with self.assertRaises(AnsibleActionFail) as error:
             self._plugin.run(task_vars=None)
-        self.assertIn(
-            "'criteria' option value is invalid", str(error.exception)
-        )
+        self.assertIn("'criteria' option value is invalid", str(error.exception))
 
     def test_invalid_validate_plugin_config_options(self):
         """Check passing invalid validate plugin options"""
@@ -195,9 +184,7 @@ class TestValidate(unittest.TestCase):
             "criteria": CRITERIA_IN_RATE_CHECK,
         }
 
-        result = self._plugin.run(
-            task_vars={"ansible_validate_jsonschema_draft": "draft0"}
-        )
+        result = self._plugin.run(task_vars={"ansible_validate_jsonschema_draft": "draft0"})
         self.assertIn(
             "value of draft must be one of: draft3, draft4, draft6, draft7, got: draft0",
             result["msg"],
@@ -212,9 +199,7 @@ class TestValidate(unittest.TestCase):
             "criteria": CRITERIA_IN_RATE_CHECK,
         }
 
-        result = self._plugin.run(
-            task_vars={"ansible_validate_jsonschema_draft": "draft3"}
-        )
+        result = self._plugin.run(task_vars={"ansible_validate_jsonschema_draft": "draft3"})
         self.assertIn("All checks passed", result["msg"])
 
     def test_validate_plugin_config_options_with_draft4(self):
@@ -226,9 +211,7 @@ class TestValidate(unittest.TestCase):
             "criteria": CRITERIA_IN_RATE_CHECK,
         }
 
-        result = self._plugin.run(
-            task_vars={"ansible_validate_jsonschema_draft": "draft4"}
-        )
+        result = self._plugin.run(task_vars={"ansible_validate_jsonschema_draft": "draft4"})
         self.assertIn("All checks passed", result["msg"])
 
     def test_validate_plugin_config_options_with_draft6(self):
@@ -240,9 +223,7 @@ class TestValidate(unittest.TestCase):
             "criteria": CRITERIA_IN_RATE_CHECK,
         }
 
-        result = self._plugin.run(
-            task_vars={"ansible_validate_jsonschema_draft": "draft6"}
-        )
+        result = self._plugin.run(task_vars={"ansible_validate_jsonschema_draft": "draft6"})
         self.assertIn("All checks passed", result["msg"])
 
     def test_invalid_data(self):
@@ -263,9 +244,7 @@ class TestValidate(unittest.TestCase):
             "patternProperties.^.*.properties.counters.properties.in_crc_errors.maximum",
             result["msg"],
         )
-        self.assertIn(
-            "patternProperties.^.*.properties.enabled.enum", result["msg"]
-        )
+        self.assertIn("patternProperties.^.*.properties.enabled.enum", result["msg"])
         self.assertIn(
             "'patternProperties.^.*.properties.oper_status.pattern",
             result["msg"],

--- a/tests/unit/plugins/filter/test_cidr_merge.py
+++ b/tests/unit/plugins/filter/test_cidr_merge.py
@@ -9,13 +9,15 @@ Unit test file for cidr_merge filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.filter.cidr_merge import (
-    _cidr_merge,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.cidr_merge import _cidr_merge
+
 
 INVALID_DATA_MERGE = ["0.1234.34.44", "1.00000.2.000.22"]
 
@@ -62,6 +64,4 @@ class TestCidrMerge(unittest.TestCase):
         kwargs = {}
         with self.assertRaises(AnsibleFilterError) as error:
             _cidr_merge(*args, **kwargs)
-        self.assertIn(
-            "cidr_merge: invalid action 'span1'", str(error.exception)
-        )
+        self.assertIn("cidr_merge: invalid action 'span1'", str(error.exception))

--- a/tests/unit/plugins/filter/test_consolidate.py
+++ b/tests/unit/plugins/filter/test_consolidate.py
@@ -5,13 +5,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.filter.consolidate import (
-    _consolidate,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.consolidate import _consolidate
 
 
 class TestConsolidate(unittest.TestCase):

--- a/tests/unit/plugins/filter/test_from_xml.py
+++ b/tests/unit/plugins/filter/test_from_xml.py
@@ -5,12 +5,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible.errors import AnsibleError
-from ansible.errors import AnsibleFilterError
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.filter.from_xml import _from_xml
+
 
 INVALID_DATA = '<netconf-state xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring">'
 

--- a/tests/unit/plugins/filter/test_hwaddr.py
+++ b/tests/unit/plugins/filter/test_hwaddr.py
@@ -9,9 +9,11 @@ Unit test file for hwaddr filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.hwaddr import _hwaddr
 
 

--- a/tests/unit/plugins/filter/test_ip4_hex.py
+++ b/tests/unit/plugins/filter/test_ip4_hex.py
@@ -9,12 +9,14 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.filter.ip4_hex import _ip4_hex
 
 from ansible.errors import AnsibleFilterError
+
+from ansible_collections.ansible.utils.plugins.filter.ip4_hex import _ip4_hex
 
 
 class TestIpWrap(unittest.TestCase):

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -8,39 +8,28 @@ Unit test file for ipaddr filter plugins
 """
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import sys
+import unittest
+
 import pytest
 
-import unittest
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import (
-    ipaddr,
-)
-from ansible_collections.ansible.utils.plugins.filter.next_nth_usable import (
-    next_nth_usable,
-)
-from ansible_collections.ansible.utils.plugins.filter.ipsubnet import ipsubnet
-from ansible_collections.ansible.utils.plugins.filter.previous_nth_usable import (
-    previous_nth_usable,
-)
-from ansible_collections.ansible.utils.plugins.filter.network_in_usable import (
-    network_in_usable,
-)
-from ansible_collections.ansible.utils.plugins.filter.network_in_network import (
-    network_in_network,
-)
-from ansible_collections.ansible.utils.plugins.filter.nthhost import nthhost
-from ansible_collections.ansible.utils.plugins.filter.reduce_on_network import (
-    reduce_on_network,
-)
-from ansible_collections.ansible.utils.plugins.filter.cidr_merge import (
-    cidr_merge,
-)
-from ansible_collections.ansible.utils.plugins.filter.ipmath import ipmath
-from ansible_collections.ansible.utils.plugins.filter.slaac import slaac
+
+from ansible_collections.ansible.utils.plugins.filter.cidr_merge import cidr_merge
 from ansible_collections.ansible.utils.plugins.filter.ip4_hex import ip4_hex
+from ansible_collections.ansible.utils.plugins.filter.ipmath import ipmath
+from ansible_collections.ansible.utils.plugins.filter.ipsubnet import ipsubnet
+from ansible_collections.ansible.utils.plugins.filter.network_in_network import network_in_network
+from ansible_collections.ansible.utils.plugins.filter.network_in_usable import network_in_usable
+from ansible_collections.ansible.utils.plugins.filter.next_nth_usable import next_nth_usable
+from ansible_collections.ansible.utils.plugins.filter.nthhost import nthhost
+from ansible_collections.ansible.utils.plugins.filter.previous_nth_usable import previous_nth_usable
+from ansible_collections.ansible.utils.plugins.filter.reduce_on_network import reduce_on_network
+from ansible_collections.ansible.utils.plugins.filter.slaac import slaac
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.ipaddr_utils import ipaddr
 
 
 netaddr = pytest.importorskip("netaddr")
@@ -48,14 +37,10 @@ netaddr = pytest.importorskip("netaddr")
 
 class TestIpFilter(unittest.TestCase):
     def test_cidr_merge(self):
-        with pytest.raises(
-            AnsibleFilterError, match="cidr_merge: expected iterable, got None"
-        ):
+        with pytest.raises(AnsibleFilterError, match="cidr_merge: expected iterable, got None"):
             cidr_merge(None)
 
-        with pytest.raises(
-            AnsibleFilterError, match="cidr_merge: invalid action 'floop'"
-        ):
+        with pytest.raises(AnsibleFilterError, match="cidr_merge: invalid action 'floop'"):
             cidr_merge([], "floop")
 
         self.assertEqual(cidr_merge([]), [])
@@ -90,9 +75,7 @@ class TestIpFilter(unittest.TestCase):
         self.assertFalse(ipaddr("fd::e", "6to4"))
         self.assertFalse(ipaddr("fd::e/20", "6to4"))
 
-        self.assertEqual(
-            ipaddr("2002:c000:02e6::1", "6to4"), "2002:c000:02e6::1"
-        )
+        self.assertEqual(ipaddr("2002:c000:02e6::1", "6to4"), "2002:c000:02e6::1")
         self.assertEqual(ipaddr(v6_address, "6to4"), v6_address)
         self.assertEqual(
             ipaddr(
@@ -254,35 +237,21 @@ class TestIpFilter(unittest.TestCase):
 
     def test_range_usable(self):
         address = "1.12.1.0/24"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.254"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.254")
         address = "1.12.1.0/25"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.126"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.126")
         address = "1.12.1.36/28"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.33-1.12.1.46"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.33-1.12.1.46")
         address = "1.12.1.36/255.255.255.240"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.33-1.12.1.46"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.33-1.12.1.46")
         address = "1.12.1.36/31"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.36-1.12.1.37"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.36-1.12.1.37")
         address = "1.12.1.37/31"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.36-1.12.1.37"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.36-1.12.1.37")
         address = "1.12.1.36/32"
         self.assertEqual(ipaddr(address, "range_usable"), None)
         address = "1.12.1.254/24"
-        self.assertEqual(
-            ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.254"
-        )
+        self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.254")
 
     def test_address_prefix(self):
         # Regular address
@@ -346,33 +315,21 @@ class TestIpFilter(unittest.TestCase):
         address = "1.12.1.0/25"
         self.assertEqual(ipaddr(address, "ip_netmask"), None)
         address = "1.12.1.36/28"
-        self.assertEqual(
-            ipaddr(address, "ip_netmask"), "1.12.1.36 255.255.255.240"
-        )
+        self.assertEqual(ipaddr(address, "ip_netmask"), "1.12.1.36 255.255.255.240")
         address = "1.12.1.36/255.255.255.240"
-        self.assertEqual(
-            ipaddr(address, "ip_netmask"), "1.12.1.36 255.255.255.240"
-        )
+        self.assertEqual(ipaddr(address, "ip_netmask"), "1.12.1.36 255.255.255.240")
         address = "1.12.1.36/31"
-        self.assertEqual(
-            ipaddr(address, "ip_netmask"), "1.12.1.36 255.255.255.254"
-        )
+        self.assertEqual(ipaddr(address, "ip_netmask"), "1.12.1.36 255.255.255.254")
         address = "1.12.1.37/31"
-        self.assertEqual(
-            ipaddr(address, "ip_netmask"), "1.12.1.37 255.255.255.254"
-        )
+        self.assertEqual(ipaddr(address, "ip_netmask"), "1.12.1.37 255.255.255.254")
         address = "1.12.1.36/32"
         self.assertEqual(ipaddr(address, "ip_netmask"), None)
         address = "1.12.1.254/24"
-        self.assertEqual(
-            ipaddr(address, "ip_netmask"), "1.12.1.254 255.255.255.0"
-        )
+        self.assertEqual(ipaddr(address, "ip_netmask"), "1.12.1.254 255.255.255.0")
 
     def test_ipv6_query(self):
         self.assertEqual(ipaddr("fd00:123::97", "ipv6"), "fd00:123::97")
-        self.assertEqual(
-            ipaddr("192.0.2.230", "ipv6"), "::ffff:192.0.2.230/128"
-        )
+        self.assertEqual(ipaddr("192.0.2.230", "ipv6"), "::ffff:192.0.2.230/128")
 
     def test_ipaddr_link_local_query(self):
         self.assertEqual(ipaddr("169.254.0.12", "link-local"), "169.254.0.12")
@@ -418,71 +375,39 @@ class TestIpFilter(unittest.TestCase):
 
     def test_network_netmask(self):
         address = "1.12.1.0/24"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.0 255.255.255.0"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.0 255.255.255.0")
         address = "1.12.1.0/25"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.0 255.255.255.128"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.0 255.255.255.128")
         address = "1.12.1.36/28"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.32 255.255.255.240"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.32 255.255.255.240")
         address = "1.12.1.36/255.255.255.240"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.32 255.255.255.240"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.32 255.255.255.240")
         address = "1.12.1.36/31"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.36 255.255.255.254"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.36 255.255.255.254")
         address = "1.12.1.37/31"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.36 255.255.255.254"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.36 255.255.255.254")
         address = "1.12.1.36/32"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.36 255.255.255.255"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.36 255.255.255.255")
         address = "1.12.1.254/24"
-        self.assertEqual(
-            ipaddr(address, "network_netmask"), "1.12.1.0 255.255.255.0"
-        )
+        self.assertEqual(ipaddr(address, "network_netmask"), "1.12.1.0 255.255.255.0")
 
     def test_network_wildcard(self):
         address = "1.12.1.0/24"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.0 0.0.0.255"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.0 0.0.0.255")
         address = "1.12.1.0/25"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.0 0.0.0.127"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.0 0.0.0.127")
         address = "1.12.1.36/28"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.32 0.0.0.15"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.32 0.0.0.15")
         address = "1.12.1.36/255.255.255.240"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.32 0.0.0.15"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.32 0.0.0.15")
         address = "1.12.1.36/31"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.36 0.0.0.1"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.36 0.0.0.1")
         address = "1.12.1.37/31"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.36 0.0.0.1"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.36 0.0.0.1")
         address = "1.12.1.36/32"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.36 0.0.0.0"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.36 0.0.0.0")
         address = "1.12.1.254/24"
-        self.assertEqual(
-            ipaddr(address, "network_wildcard"), "1.12.1.0 0.0.0.255"
-        )
+        self.assertEqual(ipaddr(address, "network_wildcard"), "1.12.1.0 0.0.0.255")
 
     def test_next_usable(self):
         address = "1.12.1.0/24"
@@ -558,19 +483,14 @@ class TestIpFilter(unittest.TestCase):
         self.assertEqual(ipmath("2001::1", 9), "2001::a")
         self.assertEqual(ipmath("2001::1", 10), "2001::b")
         self.assertEqual(ipmath("2001::5", -3), "2001::2")
-        self.assertEqual(
-            ipmath("2001::5", -10), "2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb"
-        )
+        self.assertEqual(ipmath("2001::5", -10), "2000:ffff:ffff:ffff:ffff:ffff:ffff:fffb")
 
         expected = "You must pass a valid IP address; invalid_ip is invalid"
         with self.assertRaises(AnsibleFilterError) as exc:
             ipmath("invalid_ip", 8)
         self.assertEqual(exc.exception.message, expected)
 
-        expected = (
-            "You must pass an integer for arithmetic; "
-            "some_number is not a valid integer"
-        )
+        expected = "You must pass an integer for arithmetic; " "some_number is not a valid integer"
         with self.assertRaises(AnsibleFilterError) as exc:
             ipmath("1.2.3.4", "some_number")
         self.assertEqual(exc.exception.message, expected)
@@ -636,9 +556,7 @@ class TestIpFilter(unittest.TestCase):
         address = "1.12.1.36/24"
         self.assertEqual(nthhost(address, 10), "1.12.1.10")
         address = "1.12.1.34"
-        self.assertFalse(
-            nthhost(address, "last_usable"), "Not a network address"
-        )
+        self.assertFalse(nthhost(address, "last_usable"), "Not a network address")
         address = "1.12.1.36/28"
         self.assertEqual(nthhost(address, 4), "1.12.1.36")
         address = "1.12.1.36/255.255.255.240"

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -490,7 +490,7 @@ class TestIpFilter(unittest.TestCase):
             ipmath("invalid_ip", 8)
         self.assertEqual(exc.exception.message, expected)
 
-        expected = "You must pass an integer for arithmetic; " "some_number is not a valid integer"
+        expected = "You must pass an integer for arithmetic; some_number is not a valid integer"
         with self.assertRaises(AnsibleFilterError) as exc:
             ipmath("1.2.3.4", "some_number")
         self.assertEqual(exc.exception.message, expected)

--- a/tests/unit/plugins/filter/test_ipmath.py
+++ b/tests/unit/plugins/filter/test_ipmath.py
@@ -9,10 +9,13 @@ Unit test file for ipmath filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.filter.ipmath import _ipmath
 
 

--- a/tests/unit/plugins/filter/test_ipsubnet.py
+++ b/tests/unit/plugins/filter/test_ipsubnet.py
@@ -9,9 +9,11 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.ipsubnet import _ipsubnet
 
 

--- a/tests/unit/plugins/filter/test_ipv4.py
+++ b/tests/unit/plugins/filter/test_ipv4.py
@@ -9,9 +9,11 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.ipv4 import _ipv4
 
 

--- a/tests/unit/plugins/filter/test_ipv6.py
+++ b/tests/unit/plugins/filter/test_ipv6.py
@@ -9,9 +9,11 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.ipv6 import _ipv6
 
 

--- a/tests/unit/plugins/filter/test_ipwrap.py
+++ b/tests/unit/plugins/filter/test_ipwrap.py
@@ -9,9 +9,11 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.ipwrap import _ipwrap
 
 

--- a/tests/unit/plugins/filter/test_keep_keys.py
+++ b/tests/unit/plugins/filter/test_keep_keys.py
@@ -5,13 +5,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.filter.keep_keys import (
-    _keep_keys,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.keep_keys import _keep_keys
 
 
 class TestKeepKeys(unittest.TestCase):
@@ -228,6 +229,4 @@ class TestKeepKeys(unittest.TestCase):
         args = ["", "string data", target]
         with self.assertRaises(AnsibleFilterError) as error:
             _keep_keys(*args)
-        self.assertIn(
-            "Error when using plugin 'keep_keys'", str(error.exception)
-        )
+        self.assertIn("Error when using plugin 'keep_keys'", str(error.exception))

--- a/tests/unit/plugins/filter/test_macaddr.py
+++ b/tests/unit/plugins/filter/test_macaddr.py
@@ -9,9 +9,11 @@ Unit test file for macaddr filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.macaddr import _macaddr
 
 

--- a/tests/unit/plugins/filter/test_network_in_network.py
+++ b/tests/unit/plugins/filter/test_network_in_network.py
@@ -9,12 +9,12 @@ Unit test file for network_in_network filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.filter.network_in_network import (
-    _network_in_network,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.network_in_network import _network_in_network
 
 
 class Test_network_in_network(unittest.TestCase):

--- a/tests/unit/plugins/filter/test_network_in_usable.py
+++ b/tests/unit/plugins/filter/test_network_in_usable.py
@@ -9,12 +9,12 @@ Unit test file for network_in_usable filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.filter.network_in_usable import (
-    _network_in_usable,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.network_in_usable import _network_in_usable
 
 
 class Test_Network_In_Usable(unittest.TestCase):

--- a/tests/unit/plugins/filter/test_next_nth_usable.py
+++ b/tests/unit/plugins/filter/test_next_nth_usable.py
@@ -9,12 +9,12 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.filter.next_nth_usable import (
-    _next_nth_usable,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.next_nth_usable import _next_nth_usable
 
 
 class Test_Next_Nth_Usable(unittest.TestCase):

--- a/tests/unit/plugins/filter/test_nthhost.py
+++ b/tests/unit/plugins/filter/test_nthhost.py
@@ -9,9 +9,11 @@ Unit test file for nthhost filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.nthhost import _nthhost
 
 

--- a/tests/unit/plugins/filter/test_param_list_compare.py
+++ b/tests/unit/plugins/filter/test_param_list_compare.py
@@ -6,13 +6,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.filter.param_list_compare import (
-    param_list_compare,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.param_list_compare import param_list_compare
 
 
 class TestParam_list_compare_merge(unittest.TestCase):

--- a/tests/unit/plugins/filter/test_previous_nth_usable.py
+++ b/tests/unit/plugins/filter/test_previous_nth_usable.py
@@ -9,9 +9,11 @@ Unit test file for ipwrap filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.previous_nth_usable import (
     _previous_nth_usable,
 )

--- a/tests/unit/plugins/filter/test_reduce_on_network.py
+++ b/tests/unit/plugins/filter/test_reduce_on_network.py
@@ -9,13 +9,14 @@ Unit test file for reduce_on_network filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleError
-from ansible_collections.ansible.utils.plugins.filter.reduce_on_network import (
-    _reduce_on_network,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.reduce_on_network import _reduce_on_network
 
 
 class Test_reduce_on_network(unittest.TestCase):
@@ -30,9 +31,7 @@ class Test_reduce_on_network(unittest.TestCase):
         kwargs = {}
         with self.assertRaises(AnsibleError) as error:
             _reduce_on_network(*args, **kwargs)
-        self.assertIn(
-            "missing required arguments: value", str(error.exception)
-        )
+        self.assertIn("missing required arguments: value", str(error.exception))
 
     def test_reduce_on_network_filter_1(self):
         """reduce_on_network filter"""

--- a/tests/unit/plugins/filter/test_remove_keys.py
+++ b/tests/unit/plugins/filter/test_remove_keys.py
@@ -5,13 +5,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.filter.remove_keys import (
-    _remove_keys,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.remove_keys import _remove_keys
 
 
 class TestReplaceKeys(unittest.TestCase):
@@ -305,6 +306,4 @@ class TestReplaceKeys(unittest.TestCase):
         args = ["", "string data", target]
         with self.assertRaises(AnsibleFilterError) as error:
             _remove_keys(*args)
-        self.assertIn(
-            "Error when using plugin 'remove_keys'", str(error.exception)
-        )
+        self.assertIn("Error when using plugin 'remove_keys'", str(error.exception))

--- a/tests/unit/plugins/filter/test_replace_keys.py
+++ b/tests/unit/plugins/filter/test_replace_keys.py
@@ -5,13 +5,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleFilterError
-from ansible_collections.ansible.utils.plugins.filter.replace_keys import (
-    _replace_keys,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.replace_keys import _replace_keys
 
 
 class TestReplaceKeys(unittest.TestCase):
@@ -344,6 +345,4 @@ class TestReplaceKeys(unittest.TestCase):
         args = ["", "string data", target]
         with self.assertRaises(AnsibleFilterError) as error:
             _replace_keys(*args)
-        self.assertIn(
-            "Error when using plugin 'replace_keys'", str(error.exception)
-        )
+        self.assertIn("Error when using plugin 'replace_keys'", str(error.exception))

--- a/tests/unit/plugins/filter/test_slaac.py
+++ b/tests/unit/plugins/filter/test_slaac.py
@@ -9,9 +9,11 @@ Unit test file for slaac filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.filter.slaac import _slaac
 
 

--- a/tests/unit/plugins/filter/test_to_xml.py
+++ b/tests/unit/plugins/filter/test_to_xml.py
@@ -5,19 +5,20 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible.errors import AnsibleError
-from ansible.errors import AnsibleFilterError
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.filter.to_xml import _to_xml
+
 
 INVALID_DATA = '<netconf-state xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring">'
 
 VALID_DATA = {
-    "interface-configurations": {
-        "@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg"
-    }
+    "interface-configurations": {"@xmlns": "http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg"}
 }
 
 OUTPUT = """<?xml version="1.0" encoding="utf-8"?>
@@ -36,9 +37,7 @@ class TestToXml(unittest.TestCase):
         kwargs = {}
         with self.assertRaises(AnsibleError) as error:
             _to_xml(*args, **kwargs)
-        self.assertIn(
-            "we were unable to convert to dict", str(error.exception)
-        )
+        self.assertIn("we were unable to convert to dict", str(error.exception))
 
     def test_valid_data(self):
         """Check passing valid data as per criteria"""

--- a/tests/unit/plugins/filter/test_usable_range.py
+++ b/tests/unit/plugins/filter/test_usable_range.py
@@ -9,13 +9,15 @@ Unit test file for usable_range filter plugin
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleError
-from ansible_collections.ansible.utils.plugins.filter.usable_range import (
-    _usable_range,
-)
+
+from ansible_collections.ansible.utils.plugins.filter.usable_range import _usable_range
+
 
 INVALID_DATA_1 = [
     "helloworld",

--- a/tests/unit/plugins/filter/test_validate.py
+++ b/tests/unit/plugins/filter/test_validate.py
@@ -5,12 +5,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
 
 from ansible.errors import AnsibleFilterError
+
 from ansible_collections.ansible.utils.plugins.filter.validate import validate
+
 
 DATA = {
     "GigabitEthernet0/0/0/0": {
@@ -51,11 +54,7 @@ CRITERIA_CRC_ERROR_CHECK = {
         "^.*": {
             "type": "object",
             "properties": {
-                "counters": {
-                    "properties": {
-                        "in_crc_errors": {"type": "number", "maximum": 0}
-                    }
-                }
+                "counters": {"properties": {"in_crc_errors": {"type": "number", "maximum": 0}}}
             },
         }
     },
@@ -63,9 +62,7 @@ CRITERIA_CRC_ERROR_CHECK = {
 
 CRITERIA_ENABLED_CHECK = {
     "type": "object",
-    "patternProperties": {
-        "^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}
-    },
+    "patternProperties": {"^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}},
 }
 
 CRITERIA_OPER_STATUS_UP_CHECK = {
@@ -86,11 +83,7 @@ CRITERIA_IN_RATE_CHECK = {
             "properties": {
                 "counters": {
                     "properties": {
-                        "rate": {
-                            "properties": {
-                                "in_rate": {"type": "number", "maximum": 0}
-                            }
-                        }
+                        "rate": {"properties": {"in_rate": {"type": "number", "maximum": 0}}}
                     }
                 }
             },
@@ -119,9 +112,7 @@ class TestValidate(unittest.TestCase):
         # missing required arguments
         with self.assertRaises(AnsibleFilterError) as error:
             validate([DATA])
-        self.assertIn(
-            "Missing either 'data' or 'criteria' value", str(error.exception)
-        )
+        self.assertIn("Missing either 'data' or 'criteria' value", str(error.exception))
 
         args = [DATA, [CRITERIA_IN_RATE_CHECK]]
         kwargs = {"engine": "ansible.utils.sample"}
@@ -142,9 +133,7 @@ class TestValidate(unittest.TestCase):
         kwargs = {"engine": "ansible.utils.jsonschema"}
         with self.assertRaises(AnsibleFilterError) as error:
             validate(*args, **kwargs)
-        self.assertIn(
-            "'criteria' option value is invalid", str(error.exception)
-        )
+        self.assertIn("'criteria' option value is invalid", str(error.exception))
 
     def test_invalid_validate_plugin_config_options(self):
         """Check passing invalid validate plugin options"""

--- a/tests/unit/plugins/lookup/test_validate.py
+++ b/tests/unit/plugins/lookup/test_validate.py
@@ -5,14 +5,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
 
 from ansible.errors import AnsibleLookupError
-from ansible_collections.ansible.utils.plugins.lookup.validate import (
-    LookupModule,
-)
+
+from ansible_collections.ansible.utils.plugins.lookup.validate import LookupModule
+
 
 DATA = {
     "GigabitEthernet0/0/0/0": {
@@ -53,11 +54,7 @@ CRITERIA_CRC_ERROR_CHECK = {
         "^.*": {
             "type": "object",
             "properties": {
-                "counters": {
-                    "properties": {
-                        "in_crc_errors": {"type": "number", "maximum": 0}
-                    }
-                }
+                "counters": {"properties": {"in_crc_errors": {"type": "number", "maximum": 0}}}
             },
         }
     },
@@ -65,9 +62,7 @@ CRITERIA_CRC_ERROR_CHECK = {
 
 CRITERIA_ENABLED_CHECK = {
     "type": "object",
-    "patternProperties": {
-        "^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}
-    },
+    "patternProperties": {"^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}},
 }
 
 CRITERIA_OPER_STATUS_UP_CHECK = {
@@ -88,11 +83,7 @@ CRITERIA_IN_RATE_CHECK = {
             "properties": {
                 "counters": {
                     "properties": {
-                        "rate": {
-                            "properties": {
-                                "in_rate": {"type": "number", "maximum": 0}
-                            }
-                        }
+                        "rate": {"properties": {"in_rate": {"type": "number", "maximum": 0}}}
                     }
                 }
             },
@@ -111,9 +102,7 @@ class TestValidate(unittest.TestCase):
         # missing required arguments
         with self.assertRaises(AnsibleLookupError) as error:
             self._lp.run([DATA], {})
-        self.assertIn(
-            "missing either 'data' or 'criteria' value", str(error.exception)
-        )
+        self.assertIn("missing either 'data' or 'criteria' value", str(error.exception))
 
         terms = [DATA, [CRITERIA_IN_RATE_CHECK]]
         kwargs = {"engine": "ansible.utils.sample"}
@@ -137,9 +126,7 @@ class TestValidate(unittest.TestCase):
         variables = {}
         with self.assertRaises(AnsibleLookupError) as error:
             self._lp.run(terms, variables, **kwargs)
-        self.assertIn(
-            "'criteria' option value is invalid", str(error.exception)
-        )
+        self.assertIn("'criteria' option value is invalid", str(error.exception))
 
     def test_invalid_validate_plugin_config_options(self):
         """Check passing invalid validate plugin options"""
@@ -160,9 +147,7 @@ class TestValidate(unittest.TestCase):
             result[0]["data_path"],
         )
         self.assertIn("GigabitEthernet0/0/0/1.enabled", result[1]["data_path"])
-        self.assertIn(
-            "GigabitEthernet0/0/0/0.oper_status", result[2]["data_path"]
-        )
+        self.assertIn("GigabitEthernet0/0/0/0.oper_status", result[2]["data_path"])
 
     def test_valid_data(self):
         """Check passing valid data as per criteria"""

--- a/tests/unit/plugins/sub_plugins/cli_parsers/test_json_parser.py
+++ b/tests/unit/plugins/sub_plugins/cli_parsers/test_json_parser.py
@@ -3,14 +3,13 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import json
 
+from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.json_parser import CliParser
 from ansible_collections.ansible.utils.tests.unit.compat import unittest
-from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.json_parser import (
-    CliParser,
-)
 
 
 class TestJsonParser(unittest.TestCase):

--- a/tests/unit/plugins/sub_plugins/cli_parsers/test_textfsm_parser.py
+++ b/tests/unit/plugins/sub_plugins/cli_parsers/test_textfsm_parser.py
@@ -3,25 +3,25 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import os
 
 import pytest
 
-from ansible_collections.ansible.utils.tests.unit.compat import unittest
 from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.textfsm_parser import (
     CliParser,
 )
+from ansible_collections.ansible.utils.tests.unit.compat import unittest
+
 
 textfsm = pytest.importorskip("textfsm")
 
 
 class TestTextfsmParser(unittest.TestCase):
     def test_textfsm_parser(self):
-        nxos_cfg_path = os.path.join(
-            os.path.dirname(__file__), "fixtures", "nxos_show_version.cfg"
-        )
+        nxos_cfg_path = os.path.join(os.path.dirname(__file__), "fixtures", "nxos_show_version.cfg")
         nxos_template_path = os.path.join(
             os.path.dirname(__file__), "fixtures", "nxos_show_version.textfsm"
         )
@@ -63,9 +63,5 @@ class TestTextfsmParser(unittest.TestCase):
         }
         parser = CliParser(task_args=task_args, task_vars=[], debug=False)
         result = parser.parse()
-        errors = {
-            "errors": "error while reading template_path file {0}".format(
-                fake_path
-            )
-        }
+        errors = {"errors": "error while reading template_path file {0}".format(fake_path)}
         self.assertEqual(result, errors)

--- a/tests/unit/plugins/sub_plugins/cli_parsers/test_ttp_parser.py
+++ b/tests/unit/plugins/sub_plugins/cli_parsers/test_ttp_parser.py
@@ -3,25 +3,23 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import os
 
 import pytest
 
+from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.ttp_parser import CliParser
 from ansible_collections.ansible.utils.tests.unit.compat import unittest
-from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.ttp_parser import (
-    CliParser,
-)
+
 
 textfsm = pytest.importorskip("ttp")
 
 
 class TestTextfsmParser(unittest.TestCase):
     def test_ttp_parser(self):
-        nxos_cfg_path = os.path.join(
-            os.path.dirname(__file__), "fixtures", "nxos_show_version.cfg"
-        )
+        nxos_cfg_path = os.path.join(os.path.dirname(__file__), "fixtures", "nxos_show_version.cfg")
         nxos_template_path = os.path.join(
             os.path.dirname(__file__), "fixtures", "nxos_show_version.ttp"
         )
@@ -63,9 +61,5 @@ class TestTextfsmParser(unittest.TestCase):
         }
         parser = CliParser(task_args=task_args, task_vars=[], debug=False)
         result = parser.parse()
-        errors = {
-            "errors": "error while reading template_path file {0}".format(
-                fake_path
-            )
-        }
+        errors = {"errors": "error while reading template_path file {0}".format(fake_path)}
         self.assertEqual(result, errors)

--- a/tests/unit/plugins/sub_plugins/cli_parsers/test_xml_parser.py
+++ b/tests/unit/plugins/sub_plugins/cli_parsers/test_xml_parser.py
@@ -3,16 +3,16 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 from collections import OrderedDict
 
 import pytest
 
+from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.xml_parser import CliParser
 from ansible_collections.ansible.utils.tests.unit.compat import unittest
-from ansible_collections.ansible.utils.plugins.sub_plugins.cli_parser.xml_parser import (
-    CliParser,
-)
+
 
 xmltodict = pytest.importorskip("xmltodict")
 
@@ -21,9 +21,7 @@ class TestXmlParser(unittest.TestCase):
     def test_valid_xml(self):
         xml = "<tag1><tag2 arg='foo'>text</tag2></tag1>"
         xml_dict = OrderedDict(
-            tag1=OrderedDict(
-                tag2=OrderedDict([("@arg", "foo"), ("#text", "text")])
-            )
+            tag1=OrderedDict(tag2=OrderedDict([("@arg", "foo"), ("#text", "text")]))
         )
         task_args = {"text": xml, "parser": {"os": "none"}}
         parser = CliParser(task_args=task_args, task_vars=[], debug=False)

--- a/tests/unit/plugins/sub_plugins/validate/test_config.py
+++ b/tests/unit/plugins/sub_plugins/validate/test_config.py
@@ -3,14 +3,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
-from ansible.module_utils._text import to_text
-from ansible.errors import AnsibleError
-from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import (
-    _load_validator,
-)
 import pytest
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_text
+
+from ansible_collections.ansible.utils.plugins.plugin_utils.base.validate import _load_validator
 
 
 @pytest.fixture(name="test_rule")
@@ -20,9 +21,7 @@ def criterion():
 
 @pytest.fixture(name="validator")
 def config_validator():
-    engine, result = _load_validator(
-        engine="ansible.utils.config", data="", criteria=[]
-    )
+    engine, result = _load_validator(engine="ansible.utils.config", data="", criteria=[])
     return engine
 
 
@@ -38,9 +37,7 @@ def test_check_args_missing_key(validator, test_rule, key):
     except AnsibleError as exc:
         error = to_text(exc)
 
-    assert error == 'Criteria {rule} missing "{key}" key'.format(
-        rule=original, key=key
-    )
+    assert error == 'Criteria {rule} missing "{key}" key'.format(rule=original, key=key)
 
 
 def test_invalid_yaml(validator):
@@ -53,9 +50,7 @@ def test_invalid_yaml(validator):
     except AnsibleError as exc:
         error = to_text(exc)
 
-    expected_error = (
-        "'criteria' option value is invalid, value should be valid YAML."
-    )
+    expected_error = "'criteria' option value is invalid, value should be valid YAML."
     # Don't test for exact error string, varies with Python version
     assert error.startswith(expected_error)
 
@@ -71,10 +66,8 @@ def test_invalid_action(validator, test_rule):
     except AnsibleError as exc:
         error = to_text(exc)
 
-    expected_error = (
-        'Action in criteria {item} is not one of "warn" or "fail"'.format(
-            item=original
-        )
+    expected_error = 'Action in criteria {item} is not one of "warn" or "fail"'.format(
+        item=original
     )
     assert error == expected_error
 

--- a/tests/unit/plugins/test/test_in_any_network.py
+++ b/tests/unit/plugins/test/test_in_any_network.py
@@ -9,13 +9,14 @@ Unit test file for netaddr test plugin: in_any_network
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleError
-from ansible_collections.ansible.utils.plugins.test.in_any_network import (
-    _in_any_network,
-)
+
+from ansible_collections.ansible.utils.plugins.test.in_any_network import _in_any_network
 
 
 class TestInAnyNetwork(unittest.TestCase):
@@ -39,12 +40,8 @@ class TestInAnyNetwork(unittest.TestCase):
     def test_valid_data(self):
         """Check passing valid data as per criteria"""
 
-        result = _in_any_network(
-            ip="10.1.1.1", networks=["10.0.0.0/8", "192.168.1.0/24"]
-        )
+        result = _in_any_network(ip="10.1.1.1", networks=["10.0.0.0/8", "192.168.1.0/24"])
         self.assertEqual(result, True)
 
-        result = _in_any_network(
-            ip="8.8.8.8", networks=["10.0.0.0/8", "192.168.1.0/24"]
-        )
+        result = _in_any_network(ip="8.8.8.8", networks=["10.0.0.0/8", "192.168.1.0/24"])
         self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_in_network.py
+++ b/tests/unit/plugins/test/test_in_network.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: in_network
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.in_network import (
-    _in_network,
-)
+
+from ansible_collections.ansible.utils.plugins.test.in_network import _in_network
 
 
 class TestInNetwork(unittest.TestCase):

--- a/tests/unit/plugins/test/test_in_one_network.py
+++ b/tests/unit/plugins/test/test_in_one_network.py
@@ -9,13 +9,14 @@ Unit test file for netaddr test plugin: in_one_network
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible.errors import AnsibleError
-from ansible_collections.ansible.utils.plugins.test.in_one_network import (
-    _in_one_network,
-)
+
+from ansible_collections.ansible.utils.plugins.test.in_one_network import _in_one_network
 
 
 class TestInOneNetwork(unittest.TestCase):
@@ -39,12 +40,8 @@ class TestInOneNetwork(unittest.TestCase):
     def test_valid_data(self):
         """Check passing valid data as per criteria"""
 
-        result = _in_one_network(
-            ip="10.1.1.1", networks=["10.0.0.0/8", "192.168.1.0/24"]
-        )
+        result = _in_one_network(ip="10.1.1.1", networks=["10.0.0.0/8", "192.168.1.0/24"])
         self.assertEqual(result, True)
 
-        result = _in_one_network(
-            ip="8.8.8.8", networks=["10.0.0.0/8", "10.1.1.0/24"]
-        )
+        result = _in_one_network(ip="8.8.8.8", networks=["10.0.0.0/8", "10.1.1.0/24"])
         self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_ip.py
+++ b/tests/unit/plugins/test/test_ip.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: ip
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.ip import _ip
 
 

--- a/tests/unit/plugins/test/test_ip_address.py
+++ b/tests/unit/plugins/test/test_ip_address.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ip_address
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ip_address import (
-    _ip_address,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ip_address import _ip_address
 
 
 class TestIpAddress(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv4.py
+++ b/tests/unit/plugins/test/test_ipv4.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: ipv4
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.ipv4 import _ipv4
 
 

--- a/tests/unit/plugins/test/test_ipv4_address.py
+++ b/tests/unit/plugins/test/test_ipv4_address.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv4_address
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv4_address import (
-    _ipv4_address,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv4_address import _ipv4_address
 
 
 class TestIpV4Address(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv4_hostmask.py
+++ b/tests/unit/plugins/test/test_ipv4_hostmask.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv4_hostmask
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv4_hostmask import (
-    _ipv4_hostmask,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv4_hostmask import _ipv4_hostmask
 
 
 class TestIpV4Hostmask(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv4_netmask.py
+++ b/tests/unit/plugins/test/test_ipv4_netmask.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv4_netmask
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv4_netmask import (
-    _ipv4_netmask,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv4_netmask import _ipv4_netmask
 
 
 class TestIpV4Netmask(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv6.py
+++ b/tests/unit/plugins/test/test_ipv6.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: ipv6
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.ipv6 import _ipv6
 
 

--- a/tests/unit/plugins/test/test_ipv6_address.py
+++ b/tests/unit/plugins/test/test_ipv6_address.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv6_address
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv6_address import (
-    _ipv6_address,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv6_address import _ipv6_address
 
 
 class TestIpV6Address(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv6_ipv4_mapped.py
+++ b/tests/unit/plugins/test/test_ipv6_ipv4_mapped.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv6_ipv4_mapped
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv6_ipv4_mapped import (
-    _ipv6_ipv4_mapped,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv6_ipv4_mapped import _ipv6_ipv4_mapped
 
 
 class TestIpV6IpV4Mapped(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv6_sixtofour.py
+++ b/tests/unit/plugins/test/test_ipv6_sixtofour.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv6_sixtofour
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv6_sixtofour import (
-    _ipv6_sixtofour,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv6_sixtofour import _ipv6_sixtofour
 
 
 class TestIpV6SixToFour(unittest.TestCase):

--- a/tests/unit/plugins/test/test_ipv6_teredo.py
+++ b/tests/unit/plugins/test/test_ipv6_teredo.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: ipv6_teredo
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.ipv6_teredo import (
-    _ipv6_teredo,
-)
+
+from ansible_collections.ansible.utils.plugins.test.ipv6_teredo import _ipv6_teredo
 
 
 class TestIpV6Teredo(unittest.TestCase):

--- a/tests/unit/plugins/test/test_loopback.py
+++ b/tests/unit/plugins/test/test_loopback.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: loopback
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.loopback import _loopback
 
 

--- a/tests/unit/plugins/test/test_mac.py
+++ b/tests/unit/plugins/test/test_mac.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: mac
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.mac import _mac
 
 

--- a/tests/unit/plugins/test/test_multicast.py
+++ b/tests/unit/plugins/test/test_multicast.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: multicast
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.multicast import _multicast
 
 

--- a/tests/unit/plugins/test/test_private.py
+++ b/tests/unit/plugins/test/test_private.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: private
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.private import _private
 
 

--- a/tests/unit/plugins/test/test_public.py
+++ b/tests/unit/plugins/test/test_public.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: public
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.public import _public
 
 

--- a/tests/unit/plugins/test/test_reserved.py
+++ b/tests/unit/plugins/test/test_reserved.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: reserved
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.reserved import _reserved
 
 

--- a/tests/unit/plugins/test/test_resolvable.py
+++ b/tests/unit/plugins/test/test_resolvable.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: resolvable
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.resolvable import (
-    _resolvable,
-)
+
+from ansible_collections.ansible.utils.plugins.test.resolvable import _resolvable
 
 
 class TestResolvable(unittest.TestCase):

--- a/tests/unit/plugins/test/test_subnet_of.py
+++ b/tests/unit/plugins/test/test_subnet_of.py
@@ -9,9 +9,11 @@ Unit test file for netaddr test plugin: subnet_of
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
+
 from ansible_collections.ansible.utils.plugins.test.subnet_of import _subnet_of
 
 

--- a/tests/unit/plugins/test/test_supernet_of.py
+++ b/tests/unit/plugins/test/test_supernet_of.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: supernet_of
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.supernet_of import (
-    _supernet_of,
-)
+
+from ansible_collections.ansible.utils.plugins.test.supernet_of import _supernet_of
 
 
 class TestSupernetOf(unittest.TestCase):
@@ -46,7 +46,5 @@ class TestSupernetOf(unittest.TestCase):
         result = _supernet_of(network_a="10.1.1.0/24", network_b="10.0.0.0/8")
         self.assertEqual(result, False)
 
-        result = _supernet_of(
-            network_a="10.0.0.0/8", network_b="192.168.1.0/24"
-        )
+        result = _supernet_of(network_a="10.0.0.0/8", network_b="192.168.1.0/24")
         self.assertEqual(result, False)

--- a/tests/unit/plugins/test/test_unspecified.py
+++ b/tests/unit/plugins/test/test_unspecified.py
@@ -9,12 +9,12 @@ Unit test file for netaddr test plugin: unspecified
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
-from ansible_collections.ansible.utils.plugins.test.unspecified import (
-    _unspecified,
-)
+
+from ansible_collections.ansible.utils.plugins.test.unspecified import _unspecified
 
 
 class TestUnspecified(unittest.TestCase):

--- a/tests/unit/plugins/test/test_validate.py
+++ b/tests/unit/plugins/test/test_validate.py
@@ -5,12 +5,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import unittest
 
 from ansible.errors import AnsibleError
+
 from ansible_collections.ansible.utils.plugins.test.validate import validate
+
 
 DATA = {
     "GigabitEthernet0/0/0/0": {
@@ -51,11 +54,7 @@ CRITERIA_CRC_ERROR_CHECK = {
         "^.*": {
             "type": "object",
             "properties": {
-                "counters": {
-                    "properties": {
-                        "in_crc_errors": {"type": "number", "maximum": 0}
-                    }
-                }
+                "counters": {"properties": {"in_crc_errors": {"type": "number", "maximum": 0}}}
             },
         }
     },
@@ -63,9 +62,7 @@ CRITERIA_CRC_ERROR_CHECK = {
 
 CRITERIA_ENABLED_CHECK = {
     "type": "object",
-    "patternProperties": {
-        "^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}
-    },
+    "patternProperties": {"^.*": {"type": "object", "properties": {"enabled": {"enum": [True]}}}},
 }
 
 CRITERIA_OPER_STATUS_UP_CHECK = {
@@ -86,11 +83,7 @@ CRITERIA_IN_RATE_CHECK = {
             "properties": {
                 "counters": {
                     "properties": {
-                        "rate": {
-                            "properties": {
-                                "in_rate": {"type": "number", "maximum": 0}
-                            }
-                        }
+                        "rate": {"properties": {"in_rate": {"type": "number", "maximum": 0}}}
                     }
                 }
             },
@@ -141,9 +134,7 @@ class TestValidate(unittest.TestCase):
         }
         with self.assertRaises(AnsibleError) as error:
             validate(*args, **kwargs)
-        self.assertIn(
-            "'criteria' option value is invalid", str(error.exception)
-        )
+        self.assertIn("'criteria' option value is invalid", str(error.exception))
 
     def test_invalid_validate_plugin_config_options(self):
         """Check passing invalid validate plugin options"""


### PR DESCRIPTION
##### SUMMARY
Added isort to pre-commit, with a config in isort.cfg
Increase the black line length to 100 to avoid wrapping many of the imports

##### ISSUE TYPE
CI improvements

##### COMPONENT NAME
Black, isort, pre-commit

##### ADDITIONAL INFORMATION
ansible.utils is configured as a "known first party" to place it as a local import
"add-trailing-comma" will come in a separate PR which should improve readability of some of the black changes
