### PR TITLE
Pinned textfsm to 1.1.2

### DIFF
--- a/changelogs/fragments/193.yaml
+++ b/changelogs/fragments/193.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Pinned textfsm to 1.1.2 in requirements.txt as a workaround for https://github.com/google/textfsm/issues/105.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema
-textfsm
+textfsm==1.1.2
 ttp
 xmltodict
 netaddr


### PR DESCRIPTION
##### SUMMARY

textfsm 1.1.3 version has dependency issue with six.
Pinning to 1.1.2 for now.

Fixes: #193

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt
