### PR TITLE
Fix #209 ansible.utils filters should raise AnsibleFilterError

### DIFF
--- a/changelogs/fragments/209.yaml
+++ b/changelogs/fragments/209.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix filters to only raise AnsibleFilterError exceptions (https://github.com/ansible-collections/ansible.utils/issues/209).

--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.errors import AnsibleFilterError
 
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
@@ -261,7 +261,7 @@ def _ipaddr(*args, **kwargs):
         elif isinstance(data["value"], list):
             pass
         else:
-            raise AnsibleError(
+            raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipaddr filter <{1}>".format(
                     type(data["value"]),
                     "value",
@@ -269,7 +269,7 @@ def _ipaddr(*args, **kwargs):
             )
 
     except (TypeError, ValueError):
-        raise AnsibleError(
+        raise AnsibleFilterError(
             "Unrecognized type <{0}> for ipaddr filter <{1}>".format(type(data["value"]), "value"),
         )
 

--- a/plugins/filter/ipv4.py
+++ b/plugins/filter/ipv4.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.errors import AnsibleFilterError
 
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
@@ -139,7 +139,7 @@ def _ipv4(*args, **kwargs):
         elif isinstance(data["value"], list):
             pass
         else:
-            raise AnsibleError(
+            raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipv4 filter <{1}>".format(
                     type(data["value"]),
                     "value",
@@ -147,7 +147,7 @@ def _ipv4(*args, **kwargs):
             )
 
     except (TypeError, ValueError):
-        raise AnsibleError(
+        raise AnsibleFilterError(
             "Unrecognized type <{0}> for ipv4 filter <{1}>".format(type(data["value"]), "value"),
         )
     aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipv4")

--- a/plugins/filter/ipv6.py
+++ b/plugins/filter/ipv6.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.errors import AnsibleFilterError
 
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
@@ -157,7 +157,7 @@ def _ipv6(*args, **kwargs):
         elif isinstance(data["value"], list):
             pass
         else:
-            raise AnsibleError(
+            raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipv6 filter <{1}>".format(
                     type(data["value"]),
                     "value",
@@ -165,7 +165,7 @@ def _ipv6(*args, **kwargs):
             )
 
     except (TypeError, ValueError):
-        raise AnsibleError(
+        raise AnsibleFilterError(
             "Unrecognized type <{0}> for ipv6 filter <{1}>".format(type(data["value"]), "value"),
         )
     aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipv6")

--- a/plugins/filter/ipwrap.py
+++ b/plugins/filter/ipwrap.py
@@ -12,7 +12,7 @@ import types
 
 from functools import partial
 
-from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.errors import AnsibleFilterError
 
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
@@ -160,7 +160,7 @@ def _ipwrap(*args, **kwargs):
         elif isinstance(data["value"], bool):
             pass
         else:
-            raise AnsibleError(
+            raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipwrap filter <{1}>".format(
                     type(data["value"]),
                     "value",
@@ -168,7 +168,7 @@ def _ipwrap(*args, **kwargs):
             )
 
     except (TypeError, ValueError):
-        raise AnsibleError(
+        raise AnsibleFilterError(
             "Unrecognized type <{0}> for ipwrap filter <{1}>".format(type(data["value"]), "value"),
         )
     aav = AnsibleArgSpecValidator(data=data, schema=DOCUMENTATION, name="ipwrap")

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -16,9 +16,11 @@ import unittest
 import pytest
 
 from ansible.errors import AnsibleFilterError
+from ansible.template import AnsibleUndefined
 
 from ansible_collections.ansible.utils.plugins.filter.cidr_merge import cidr_merge
 from ansible_collections.ansible.utils.plugins.filter.ip4_hex import ip4_hex
+from ansible_collections.ansible.utils.plugins.filter.ipaddr import _ipaddr
 from ansible_collections.ansible.utils.plugins.filter.ipmath import ipmath
 from ansible_collections.ansible.utils.plugins.filter.ipsubnet import ipsubnet
 from ansible_collections.ansible.utils.plugins.filter.network_in_network import network_in_network
@@ -56,6 +58,12 @@ class TestIpFilter(unittest.TestCase):
         subnets = ["1.12.1.1", "1.12.1.255"]
         self.assertEqual(cidr_merge(subnets), ["1.12.1.1/32", "1.12.1.255/32"])
         self.assertEqual(cidr_merge(subnets, "span"), "1.12.1.0/24")
+
+    def test_ipaddr_undefined_value(self):
+        """Check ipaddr filter undefined value"""
+        args = ["", AnsibleUndefined(name="my_ip"), ""]
+        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipaddr filter <value>"):
+            _ipaddr(*args)
 
     def test_ipaddr_empty_query(self):
         self.assertEqual(ipaddr("192.0.2.230"), "192.0.2.230")

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -62,7 +62,10 @@ class TestIpFilter(unittest.TestCase):
     def test_ipaddr_undefined_value(self):
         """Check ipaddr filter undefined value"""
         args = ["", AnsibleUndefined(name="my_ip"), ""]
-        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipaddr filter <value>"):
+        with pytest.raises(
+            AnsibleFilterError,
+            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipaddr filter <value>",
+        ):
             _ipaddr(*args)
 
     def test_ipaddr_empty_query(self):

--- a/tests/unit/plugins/filter/test_ipv4.py
+++ b/tests/unit/plugins/filter/test_ipv4.py
@@ -48,7 +48,10 @@ class TestIp4(unittest.TestCase):
     def test_ipv4_undefined_value(self):
         """Check ipv4 filter undefined value"""
         args = ["", AnsibleUndefined(name="my_ip"), ""]
-        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv4 filter <value>"):
+        with pytest.raises(
+            AnsibleFilterError,
+            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv4 filter <value>",
+        ):
             _ipv4(*args)
 
     def test_ipv4_filter_empty_query(self):

--- a/tests/unit/plugins/filter/test_ipv4.py
+++ b/tests/unit/plugins/filter/test_ipv4.py
@@ -14,6 +14,11 @@ __metaclass__ = type
 
 import unittest
 
+import pytest
+
+from ansible.errors import AnsibleFilterError
+from ansible.template import AnsibleUndefined
+
 from ansible_collections.ansible.utils.plugins.filter.ipv4 import _ipv4
 
 
@@ -39,6 +44,12 @@ VALID_OUTPUT2 = ["192.24.2.1"]
 class TestIp4(unittest.TestCase):
     def setUp(self):
         pass
+
+    def test_ipv4_undefined_value(self):
+        """Check ipv4 filter undefined value"""
+        args = ["", AnsibleUndefined(name="my_ip"), ""]
+        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv4 filter <value>"):
+            _ipv4(*args)
 
     def test_ipv4_filter_empty_query(self):
         """Check ipv4 filter empty query"""

--- a/tests/unit/plugins/filter/test_ipv6.py
+++ b/tests/unit/plugins/filter/test_ipv6.py
@@ -51,7 +51,10 @@ class TestIp6(unittest.TestCase):
     def test_ipv6_undefined_value(self):
         """Check ipv6 filter undefined value"""
         args = ["", AnsibleUndefined(name="my_ip"), ""]
-        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv6 filter <value>"):
+        with pytest.raises(
+            AnsibleFilterError,
+            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv6 filter <value>",
+        ):
             _ipv6(*args)
 
     def test_ipv6_filter_empty_query(self):

--- a/tests/unit/plugins/filter/test_ipv6.py
+++ b/tests/unit/plugins/filter/test_ipv6.py
@@ -14,6 +14,11 @@ __metaclass__ = type
 
 import unittest
 
+import pytest
+
+from ansible.errors import AnsibleFilterError
+from ansible.template import AnsibleUndefined
+
 from ansible_collections.ansible.utils.plugins.filter.ipv6 import _ipv6
 
 
@@ -42,6 +47,12 @@ VALID_OUTPUT2 = ["::ffff:192.168.32.0", "::ffff:192.24.2.1", "fe80::100"]
 class TestIp6(unittest.TestCase):
     def setUp(self):
         pass
+
+    def test_ipv6_undefined_value(self):
+        """Check ipv6 filter undefined value"""
+        args = ["", AnsibleUndefined(name="my_ip"), ""]
+        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv6 filter <value>"):
+            _ipv6(*args)
 
     def test_ipv6_filter_empty_query(self):
         """Check ipv6 filter empty query"""

--- a/tests/unit/plugins/filter/test_ipwrap.py
+++ b/tests/unit/plugins/filter/test_ipwrap.py
@@ -14,6 +14,11 @@ __metaclass__ = type
 
 import unittest
 
+import pytest
+
+from ansible.errors import AnsibleFilterError
+from ansible.template import AnsibleUndefined
+
 from ansible_collections.ansible.utils.plugins.filter.ipwrap import _ipwrap
 
 
@@ -44,6 +49,12 @@ VALID_OUTPUT = [
 class TestIpWrap(unittest.TestCase):
     def setUp(self):
         pass
+
+    def test_ipwrap_undefined_value(self):
+        """Check ipwrap filter undefined value"""
+        args = ["", AnsibleUndefined(name="my_ip"), ""]
+        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipwrap filter <value>"):
+            _ipwrap(*args)
 
     def test_valid_data_list(self):
         """Check passing valid argspec(list)"""

--- a/tests/unit/plugins/filter/test_ipwrap.py
+++ b/tests/unit/plugins/filter/test_ipwrap.py
@@ -53,7 +53,10 @@ class TestIpWrap(unittest.TestCase):
     def test_ipwrap_undefined_value(self):
         """Check ipwrap filter undefined value"""
         args = ["", AnsibleUndefined(name="my_ip"), ""]
-        with pytest.raises(AnsibleFilterError, match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipwrap filter <value>"):
+        with pytest.raises(
+            AnsibleFilterError,
+            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipwrap filter <value>",
+        ):
             _ipwrap(*args)
 
     def test_valid_data_list(self):


### PR DESCRIPTION
##### SUMMARY
With the changes from [PR149](https://github.com/ansible-collections/ansible.utils/pull/149) ansible.utils raises the base `AnsibleError` for invalid input values instead of `AnsibleFilterError`. Where possible the more specific error should be raised.

An example of this can be seen with [ansible-lint](https://github.com/ansible/ansible-lint/issues/2468) where the `AnsibleError` triggers the `jinja[invalid]` linting rule. If the filters would use `AnsibleFilterError` it would see that the problem lies with a filter, not with the template itself.

Fixes #209 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.utils filters