### PR TITLE
Fix filter and test docs

### DIFF
--- a/changelogs/fragments/217-test-filter-docs.yaml
+++ b/changelogs/fragments/217-test-filter-docs.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fix the filter and test documentation to render well on the Ansible docsite.

--- a/docs/ansible.utils.in_any_network_test.rst
+++ b/docs/ansible.utils.in_any_network_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents an IP address of a host or network</div>
-                        <div>{&#x27;For example&#x27;: &#x27;10.1.1.1&#x27;}</div>
+                        <div>For example: <code>10.1.1.1</code></div>
                 </td>
             </tr>
             <tr>
@@ -69,7 +69,7 @@ Parameters
                     </td>
                 <td>
                         <div>A list of string and each string represents a network address in CIDR form</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/8&#x27;, &#x27;192.168.1.0/24&#x27;]}</div>
+                        <div>For example: <code>[&#x27;10.0.0.0/8&#x27;, &#x27;192.168.1.0/24&#x27;]</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.in_network_test.rst
+++ b/docs/ansible.utils.in_network_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents an IP address</div>
-                        <div>{&#x27;For example&#x27;: &#x27;10.1.1.1&#x27;}</div>
+                        <div>For example: <code>10.1.1.1</code></div>
                 </td>
             </tr>
             <tr>
@@ -69,7 +69,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the network address in CIDR form</div>
-                        <div>{&#x27;For example&#x27;: &#x27;10.0.0.0/8&#x27;}</div>
+                        <div>For example: <code>10.0.0.0/8</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.in_one_network_test.rst
+++ b/docs/ansible.utils.in_one_network_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents an IP address</div>
-                        <div>{&#x27;For example&#x27;: &#x27;10.1.1.1&#x27;}</div>
+                        <div>For example: <code>10.1.1.1</code></div>
                 </td>
             </tr>
             <tr>
@@ -69,7 +69,7 @@ Parameters
                     </td>
                 <td>
                         <div>A list of string and each string represents a network address in CIDR form</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/8&#x27;, &#x27;192.168.1.0/24&#x27;]}</div>
+                        <div>For example: <code>[&#x27;10.0.0.0/8&#x27;, &#x27;192.168.1.0/24&#x27;]</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.index_of_filter.rst
+++ b/docs/ansible.utils.index_of_filter.rst
@@ -132,7 +132,7 @@ Parameters
                     </td>
                 <td>
                         <div>The value used to test each list item against.</div>
-                        <div>{&#x27;Not required for simple tests (eg&#x27;: &#x27;<code>true</code>, <code>false</code>, <code>even</code>, <code>odd</code>)&#x27;}</div>
+                        <div>Not required for simple tests (eg: <code>true</code>, <code>false</code>, <code>even</code>, <code>odd</code>)</div>
                         <div>May be a <code>string</code>, <code>boolean</code>, <code>number</code>, <code>regular expression</code> <code>dict</code> and so on, depending on the <code>test</code> used</div>
                 </td>
             </tr>

--- a/docs/ansible.utils.ip_address_test.rst
+++ b/docs/ansible.utils.ip_address_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;hello-world&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code> or <code>&quot;hello-world&quot;</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ip_test.rst
+++ b/docs/ansible.utils.ip_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;2001:db8:a::123&#x27;, &#x27;hello-world&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code>, <code>2001:db8:a::123</code>, or <code>&quot;hello-world&quot;</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipaddr_filter.rst
+++ b/docs/ansible.utils.ipaddr_filter.rst
@@ -69,7 +69,7 @@ Parameters
                 <td>
                         <div>You can provide a single argument to each ipaddr() filter.</div>
                         <div>The filter will then treat it as a query and return values modified by that query.</div>
-                        <div>{&#x27;Types of queries include&#x27;: [{&#x27;query by name&#x27;: &quot;ansible.utils.ipaddr(&#x27;address&#x27;), ansible.utils.ipv4(&#x27;network&#x27;);&quot;}, {&#x27;query by CIDR range&#x27;: &quot;ansible.utils.ipaddr(&#x27;192.168.0.0/24&#x27;), ansible.utils.ipv6(&#x27;2001:db8::/32&#x27;);&quot;}, {&#x27;query by index number&#x27;: &quot;ansible.utils.ipaddr(&#x27;1&#x27;), ansible.utils.ipaddr(&#x27;-1&#x27;);&quot;}]}</div>
+                        <div>Types of queries include: 1. query by name: ansible.utils.ipaddr(&#x27;address&#x27;), ansible.utils.ipv4(&#x27;network&#x27;); 2. query by CIDR range: ansible.utils.ipaddr(&#x27;192.168.0.0/24&#x27;), ansible.utils.ipv6(&#x27;2001:db8::/32&#x27;); 3. query by index number: ansible.utils.ipaddr(&#x27;1&#x27;), ansible.utils.ipaddr(&#x27;-1&#x27;);</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.utils.ipv4_address_test.rst
+++ b/docs/ansible.utils.ipv4_address_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;10.0.0.0/8&#x27;, &#x27;fe80::216:3eff:fee4:16f3&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code>, <code>10.0.0.0/8</code>, or <code>fe80::216:3eff:fee4:16f3</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv4_hostmask_test.rst
+++ b/docs/ansible.utils.ipv4_hostmask_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;0.1.255.255&#x27;, &#x27;255.255.255.0&#x27;]}</div>
+                        <div>For example: <code>0.1.255.255</code> or <code>255.255.255.0</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv4_netmask_test.rst
+++ b/docs/ansible.utils.ipv4_netmask_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;0.1.255.255&#x27;, &#x27;255.255.255.0&#x27;]}</div>
+                        <div>For example: <code>0.1.255.255</code> or <code>255.255.255.0</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv4_test.rst
+++ b/docs/ansible.utils.ipv4_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;10.0.0.0/8&#x27;, &#x27;fe80::216:3eff:fee4:16f3&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code>, <code>10.0.0.0/8</code>, or <code>fe80::216:3eff:fee4:16f3</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv6_address_test.rst
+++ b/docs/ansible.utils.ipv6_address_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;10.0.0.0/8&#x27;, &#x27;fe80::216:3eff:fee4:16f3&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code>, <code>10.0.0.0/8</code>, or <code>fe80::216:3eff:fee4:16f3</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv6_ipv4_mapped_test.rst
+++ b/docs/ansible.utils.ipv6_ipv4_mapped_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;::FFFF:10.1.1.1&#x27;, &#x27;::AAAA:10.1.1.1&#x27;, &#x27;helloworld&#x27;]}</div>
+                        <div>For example: <code>::FFFF:10.1.1.1</code>, <code>::AAAA:10.1.1.1</code>, or <code>&quot;helloworld&quot;</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv6_sixtofour_test.rst
+++ b/docs/ansible.utils.ipv6_sixtofour_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;2002:c0a8:6301:1::1&#x27;, &#x27;::AAAA:10.1.1.1&#x27;, &#x27;hello_world&#x27;]}</div>
+                        <div>For example: <code>2002:c0a8:6301:1::1</code>, <code>::AAAA:10.1.1.1</code>, or <code>&quot;hello_world&quot;</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv6_teredo_test.rst
+++ b/docs/ansible.utils.ipv6_teredo_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;2001::c0a8:6301:1&#x27;, &#x27;2002::c0a8:6301:1&#x27;, &#x27;hello_world&#x27;]}</div>
+                        <div>For example: <code>2001::c0a8:6301:1</code>, <code>2002::c0a8:6301:1</code>, or <code>&quot;hello_world&quot;</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.ipv6_test.rst
+++ b/docs/ansible.utils.ipv6_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;10.0.0.0/8&#x27;, &#x27;fe80::216:3eff:fee4:16f3&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code>, <code>10.0.0.0/8</code>, or <code>fe80::216:3eff:fee4:16f3</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.loopback_test.rst
+++ b/docs/ansible.utils.loopback_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;127.0.0.1&#x27;, &#x27;2002::c0a8:6301:1&#x27;]}</div>
+                        <div>For example: <code>127.0.0.1</code> or <code>2002::c0a8:6301:1</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.mac_test.rst
+++ b/docs/ansible.utils.mac_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;02:16:3e:e4:16:f3&#x27;, &#x27;02-16-3e-e4-16-f3&#x27;, &#x27;0216.3ee4.16f3&#x27;, &#x27;02163ee416f3&#x27;]}</div>
+                        <div>For example: <code>02:16:3e:e4:16:f3</code>, <code>02-16-3e-e4-16-f3</code>, <code>0216.3ee4.16f3</code>, or <code>02163ee416f3</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.multicast_test.rst
+++ b/docs/ansible.utils.multicast_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;224.0.0.1&#x27;, &#x27;127.0.0.1&#x27;]}</div>
+                        <div>For example: <code>224.0.0.1</code> or <code>127.0.0.1</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.private_test.rst
+++ b/docs/ansible.utils.private_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.1&#x27;, &#x27;8.8.8.8&#x27;, &#x27;192.168.1.250&#x27;]}</div>
+                        <div>For example: <code>10.1.1.1</code>, <code>8.8.8.8</code>, or <code>192.168.1.250</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.public_test.rst
+++ b/docs/ansible.utils.public_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;8.8.8.8&#x27;, &#x27;10.1.1.1&#x27;, &#x27;192.168.1.250&#x27;]}</div>
+                        <div>For example: <code>8.8.8.8</code>, <code>10.1.1.1</code>, or <code>192.168.1.250</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.reserved_test.rst
+++ b/docs/ansible.utils.reserved_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;253.0.0.1&#x27;, &#x27;128.146.1.7&#x27;]}</div>
+                        <div>For example: <code>253.0.0.1</code> or <code>128.146.1.7</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.resolvable_test.rst
+++ b/docs/ansible.utils.resolvable_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the IP address or the host name</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;docs.ansible.com&#x27;, &#x27;127.0.0.1&#x27;, &#x27;::1&#x27;]}</div>
+                        <div>For example: <code>&quot;docs.ansible.com&quot;</code>, <code>127.0.0.1</code>, or <code>::1</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.subnet_of_test.rst
+++ b/docs/ansible.utils.subnet_of_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the first network address</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.0/24&#x27;]}</div>
+                        <div>For example: <code>10.1.1.0/24</code></div>
                 </td>
             </tr>
             <tr>
@@ -69,7 +69,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the second network address</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/8&#x27;]}</div>
+                        <div>For example: <code>10.0.0.0/8</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.supernet_of_test.rst
+++ b/docs/ansible.utils.supernet_of_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the first network address</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.1.1.0/24&#x27;]}</div>
+                        <div>For example: <code>10.1.1.0/24</code></div>
                 </td>
             </tr>
             <tr>
@@ -69,7 +69,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the second network address</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/8&#x27;]}</div>
+                        <div>For example: <code>10.0.0.0/8</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.unspecified_test.rst
+++ b/docs/ansible.utils.unspecified_test.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents the value against which the test is going to be performed</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;0.0.0.0&#x27;, &#x27;0:0:0:0:0:0:0:0&#x27;, &#x27;::&#x27;, &#x27;::1&#x27;]}</div>
+                        <div>For example: <code>0.0.0.0</code>, <code>0:0:0:0:0:0:0:0</code>, <code>::</code>, or <code>::1</code></div>
                 </td>
             </tr>
     </table>

--- a/docs/ansible.utils.usable_range_filter.rst
+++ b/docs/ansible.utils.usable_range_filter.rst
@@ -50,7 +50,7 @@ Parameters
                     </td>
                 <td>
                         <div>A string that represents an IP address of network in CIDR form</div>
-                        <div>{&#x27;For example&#x27;: [&#x27;10.0.0.0/24&#x27;, &#x27;2001:db8:abcd:0012::0/124&#x27;]}</div>
+                        <div>For example: <code>10.0.0.0/24</code> or <code>2001:db8:abcd:0012::0/124</code></div>
                 </td>
             </tr>
     </table>

--- a/plugins/filter/index_of.py
+++ b/plugins/filter/index_of.py
@@ -40,7 +40,7 @@ DOCUMENTATION = """
       value:
         description:
         - The value used to test each list item against.
-        - Not required for simple tests (eg: C(true), C(false), C(even), C(odd))
+        - 'Not required for simple tests (eg: C(true), C(false), C(even), C(odd))'
         - May be a C(string), C(boolean), C(number), C(regular expression) C(dict) and so on, depending on the C(test) used
         type: raw
       key:

--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -61,10 +61,11 @@ DOCUMENTATION = """
             description:
             - You can provide a single argument to each ipaddr() filter.
             - The filter will then treat it as a query and return values modified by that query.
-            - Types of queries include:
-                - query by name: ansible.utils.ipaddr('address'), ansible.utils.ipv4('network');
-                - query by CIDR range: ansible.utils.ipaddr('192.168.0.0/24'), ansible.utils.ipv6('2001:db8::/32');
-                - query by index number: ansible.utils.ipaddr('1'), ansible.utils.ipaddr('-1');
+            - >-
+              Types of queries include:
+              1. query by name: ansible.utils.ipaddr('address'), ansible.utils.ipv4('network');
+              2. query by CIDR range: ansible.utils.ipaddr('192.168.0.0/24'), ansible.utils.ipv6('2001:db8::/32');
+              3. query by index number: ansible.utils.ipaddr('1'), ansible.utils.ipaddr('-1');
             type: str
             default: ''
         version:

--- a/plugins/filter/usable_range.py
+++ b/plugins/filter/usable_range.py
@@ -31,9 +31,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents an IP address of network in CIDR form
-            - For example:
-                - "10.0.0.0/24"
-                - "2001:db8:abcd:0012::0/124"
+            - 'For example: C(10.0.0.0/24) or C(2001:db8:abcd:0012::0/124)'
             type: str
             required: True
     notes:

--- a/plugins/test/in_any_network.py
+++ b/plugins/test/in_any_network.py
@@ -26,13 +26,13 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents an IP address of a host or network
-            - For example: "10.1.1.1"
+            - 'For example: C(10.1.1.1)'
             type: str
             required: True
         networks:
             description:
             - A list of string and each string represents a network address in CIDR form
-            - For example: ['10.0.0.0/8', '192.168.1.0/24']
+            - "For example: C(['10.0.0.0/8', '192.168.1.0/24'])"
             type: list
             required: True
     notes:

--- a/plugins/test/in_network.py
+++ b/plugins/test/in_network.py
@@ -30,13 +30,13 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents an IP address
-            - For example: "10.1.1.1"
+            - 'For example: C(10.1.1.1)'
             type: str
             required: True
         network:
             description:
             - A string that represents the network address in CIDR form
-            - For example: "10.0.0.0/8"
+            - 'For example: C(10.0.0.0/8)'
             type: str
             required: True
     notes:

--- a/plugins/test/in_one_network.py
+++ b/plugins/test/in_one_network.py
@@ -28,13 +28,13 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents an IP address
-            - For example: "10.1.1.1"
+            - 'For example: C(10.1.1.1)'
             type: str
             required: True
         networks:
             description:
             - A list of string and each string represents a network address in CIDR form
-            - For example: ['10.0.0.0/8', '192.168.1.0/24']
+            - "For example: C(['10.0.0.0/8', '192.168.1.0/24'])"
             type: list
             required: True
     notes:

--- a/plugins/test/ip.py
+++ b/plugins/test/ip.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "2001:db8:a::123"
-                - "hello-world"
+            - 'For example: C(10.1.1.1), C(2001:db8:a::123), or C("hello-world")'
             type: str
             required: True
     notes:

--- a/plugins/test/ip_address.py
+++ b/plugins/test/ip_address.py
@@ -29,9 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "hello-world"
+            - 'For example: C(10.1.1.1) or C("hello-world")'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv4.py
+++ b/plugins/test/ipv4.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "10.0.0.0/8"
-                - "fe80::216:3eff:fee4:16f3"
+            - 'For example: C(10.1.1.1), C(10.0.0.0/8), or C(fe80::216:3eff:fee4:16f3)'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv4_address.py
+++ b/plugins/test/ipv4_address.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "10.0.0.0/8"
-                - "fe80::216:3eff:fee4:16f3"
+            - 'For example: C(10.1.1.1), C(10.0.0.0/8), or C(fe80::216:3eff:fee4:16f3)'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv4_hostmask.py
+++ b/plugins/test/ipv4_hostmask.py
@@ -29,9 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "0.1.255.255"
-                - "255.255.255.0"
+            - 'For example: C(0.1.255.255) or C(255.255.255.0)'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv4_netmask.py
+++ b/plugins/test/ipv4_netmask.py
@@ -29,9 +29,7 @@ DOCUMENTATION = """
         mask:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "0.1.255.255"
-                - "255.255.255.0"
+            - 'For example: C(0.1.255.255) or C(255.255.255.0)'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv6.py
+++ b/plugins/test/ipv6.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "10.0.0.0/8"
-                - "fe80::216:3eff:fee4:16f3"
+            - 'For example: C(10.1.1.1), C(10.0.0.0/8), or C(fe80::216:3eff:fee4:16f3)'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv6_address.py
+++ b/plugins/test/ipv6_address.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "10.0.0.0/8"
-                - "fe80::216:3eff:fee4:16f3"
+            - 'For example: C(10.1.1.1), C(10.0.0.0/8), or C(fe80::216:3eff:fee4:16f3)'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv6_ipv4_mapped.py
+++ b/plugins/test/ipv6_ipv4_mapped.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "::FFFF:10.1.1.1"
-                - "::AAAA:10.1.1.1"
-                - "helloworld"
+            - 'For example: C(::FFFF:10.1.1.1), C(::AAAA:10.1.1.1), or C("helloworld")'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv6_sixtofour.py
+++ b/plugins/test/ipv6_sixtofour.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "2002:c0a8:6301:1::1"
-                - "::AAAA:10.1.1.1"
-                - "hello_world"
+            - 'For example: C(2002:c0a8:6301:1::1), C(::AAAA:10.1.1.1), or C("hello_world")'
             type: str
             required: True
     notes:

--- a/plugins/test/ipv6_teredo.py
+++ b/plugins/test/ipv6_teredo.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "2001::c0a8:6301:1"
-                - "2002::c0a8:6301:1"
-                - "hello_world"
+            - 'For example: C(2001::c0a8:6301:1), C(2002::c0a8:6301:1), or C("hello_world")'
             type: str
             required: True
     notes:

--- a/plugins/test/loopback.py
+++ b/plugins/test/loopback.py
@@ -29,9 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "127.0.0.1"
-                - "2002::c0a8:6301:1"
+            - 'For example: C(127.0.0.1) or C(2002::c0a8:6301:1)'
             type: str
             required: True
     notes:

--- a/plugins/test/mac.py
+++ b/plugins/test/mac.py
@@ -27,11 +27,7 @@ DOCUMENTATION = """
         mac:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "02:16:3e:e4:16:f3"
-                - "02-16-3e-e4-16-f3"
-                - "0216.3ee4.16f3"
-                - "02163ee416f3"
+            - 'For example: C(02:16:3e:e4:16:f3), C(02-16-3e-e4-16-f3), C(0216.3ee4.16f3), or C(02163ee416f3)'
             type: str
             required: True
     notes:

--- a/plugins/test/multicast.py
+++ b/plugins/test/multicast.py
@@ -29,9 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "224.0.0.1"
-                - "127.0.0.1"
+            - 'For example: C(224.0.0.1) or C(127.0.0.1)'
             type: str
             required: True
     notes:

--- a/plugins/test/private.py
+++ b/plugins/test/private.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "10.1.1.1"
-                - "8.8.8.8"
-                - "192.168.1.250"
+            - 'For example: C(10.1.1.1), C(8.8.8.8), or C(192.168.1.250)'
             type: str
             required: True
     notes:

--- a/plugins/test/public.py
+++ b/plugins/test/public.py
@@ -29,10 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "8.8.8.8"
-                - "10.1.1.1"
-                - "192.168.1.250"
+            - 'For example: C(8.8.8.8), C(10.1.1.1), or C(192.168.1.250)'
             type: str
             required: True
     notes:

--- a/plugins/test/reserved.py
+++ b/plugins/test/reserved.py
@@ -29,9 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "253.0.0.1"
-                - "128.146.1.7"
+            - 'For example: C(253.0.0.1) or C(128.146.1.7)'
             type: str
             required: True
     notes:

--- a/plugins/test/resolvable.py
+++ b/plugins/test/resolvable.py
@@ -36,10 +36,7 @@ DOCUMENTATION = """
         host:
             description:
             - A string that represents the IP address or the host name
-            - For example:
-                - "docs.ansible.com"
-                - 127.0.0.1
-                - ::1
+            - 'For example: C("docs.ansible.com"), C(127.0.0.1), or C(::1)'
             type: str
             required: True
     notes:

--- a/plugins/test/subnet_of.py
+++ b/plugins/test/subnet_of.py
@@ -30,15 +30,13 @@ DOCUMENTATION = """
         network_a:
             description:
             - A string that represents the first network address
-            - For example:
-                - "10.1.1.0/24"
+            - 'For example: C(10.1.1.0/24)'
             type: str
             required: True
         network_b:
             description:
             - A string that represents the second network address
-            - For example:
-                - "10.0.0.0/8"
+            - 'For example: C(10.0.0.0/8)'
             type: str
             required: True
     notes:

--- a/plugins/test/supernet_of.py
+++ b/plugins/test/supernet_of.py
@@ -30,15 +30,13 @@ DOCUMENTATION = """
         network_a:
             description:
             - A string that represents the first network address
-            - For example:
-                - "10.1.1.0/24"
+            - 'For example: C(10.1.1.0/24)'
             type: str
             required: True
         network_b:
             description:
             - A string that represents the second network address
-            - For example:
-                - "10.0.0.0/8"
+            - 'For example: C(10.0.0.0/8)'
             type: str
             required: True
     notes:

--- a/plugins/test/unspecified.py
+++ b/plugins/test/unspecified.py
@@ -29,11 +29,7 @@ DOCUMENTATION = """
         ip:
             description:
             - A string that represents the value against which the test is going to be performed
-            - For example:
-                - "0.0.0.0"
-                - "0:0:0:0:0:0:0:0"
-                - "::"
-                - "::1"
+            - 'For example: C(0.0.0.0), C(0:0:0:0:0:0:0:0), C(::), or C(::1)'
             type: str
             required: True
     notes:


### PR DESCRIPTION
##### SUMMARY
Right now some filter plugins (https://docs.ansible.com/ansible/devel/collections/ansible/utils/#filter-plugins) and most test plugins (https://docs.ansible.com/ansible/devel/collections/ansible/utils/#test-plugins) have broken documentation and do not render on the Ansible docsite. The first commit (1b8adac78229191b438cb72d5ec996101896720a) in this PR fixes this.

The other commits adjust the filter and test docs to the basic standards set by the filter and test docs included in ansible-core, by calling the primary input `_input`, the return value `_value`, and using `positional:` to determine which parameters are positional parameters and in which orders these appear.

I checked the result with `antsibull-docs lint-collection-docs . --plugin-docs` (needs `main` branch of antsibull-docs).

CC @samccann

Fixes #214

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
filter and test plugins
