### PR TITLE
Accept int input for ipaddr ipv4 and ipv6 filters

### DIFF
--- a/changelogs/fragments/Bugfix_162_accept_int_input.yaml
+++ b/changelogs/fragments/Bugfix_162_accept_int_input.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Accept int input for ipaddr filter.
+  - Accept int input for ipaddr filters.

--- a/changelogs/fragments/Bugfix_162_accept_int_input.yaml
+++ b/changelogs/fragments/Bugfix_162_accept_int_input.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Accept int input for ipaddr filter.

--- a/plugins/filter/ipaddr.py
+++ b/plugins/filter/ipaddr.py
@@ -261,6 +261,8 @@ def _ipaddr(*args, **kwargs):
             pass
         elif isinstance(data["value"], list):
             pass
+        elif isinstance(data["value"], int):
+            pass
         else:
             raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipaddr filter <{1}>".format(

--- a/plugins/filter/ipv4.py
+++ b/plugins/filter/ipv4.py
@@ -138,6 +138,8 @@ def _ipv4(*args, **kwargs):
             pass
         elif isinstance(data["value"], list):
             pass
+        elif isinstance(data["value"], int):
+            pass
         else:
             raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipv4 filter <{1}>".format(

--- a/plugins/filter/ipv6.py
+++ b/plugins/filter/ipv6.py
@@ -156,6 +156,8 @@ def _ipv6(*args, **kwargs):
             pass
         elif isinstance(data["value"], list):
             pass
+        elif isinstance(data["value"], int):
+            pass
         else:
             raise AnsibleFilterError(
                 "Unrecognized type <{0}> for ipv6 filter <{1}>".format(

--- a/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
@@ -57,3 +57,18 @@
 - name: Assert result for ipaddr filter with chained filters
   assert:
     that: "{{ result6 == '192.168.255.123' }}"
+
+- debug:
+    msg: "Test int input for ipaddr filter"
+
+- name: set fact 1
+  set_fact:
+      ip1: "172.20.0.1"
+
+- name: Set fact 2
+  set_fact:
+      ip2: "{{ ((ip1 | ipaddr('int')) + 6) | ipaddr }}"
+
+- name: Assert result for ipaddr filter
+  assert:
+    that: "{{ ip2 == '172.20.0.7' }}"

--- a/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
@@ -63,11 +63,11 @@
 
 - name: set fact 1
   set_fact:
-      ip1: "172.20.0.1"
+    ip1: "172.20.0.1"
 
 - name: Set fact 2
   set_fact:
-      ip2: "{{ ((ip1 | ipaddr('int')) + 6) | ipaddr }}"
+    ip2: "{{ ((ip1 | ipaddr('int')) + 6) | ipaddr }}"
 
 - name: Assert result for ipaddr filter
   assert:

--- a/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
@@ -67,7 +67,7 @@
 
 - name: Set fact 2
   set_fact:
-    ip2: "{{ ((ip1 | ipaddr('int')) + 6) | ipaddr }}"
+    ip2: "{{ ((ip1 | ansible.utils.ipaddr('int')) + 6) | ansible.utils.ipaddr }}"
 
 - name: Assert result for ipaddr filter
   assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: https://github.com/ansible-collections/ansible.utils/issues/162
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
