### PR TITLE
fix: netaddr is_private method deprecation

### DIFF
--- a/changelogs/fragments/netaddr_is_private_deprecation.yaml
+++ b/changelogs/fragments/netaddr_is_private_deprecation.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use netaddr is_global() function instead of the deprecated is_private() function.
+    (https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0)
+  - Remove reserved IPv6 from integration test expected results.

--- a/changelogs/fragments/netaddr_is_private_deprecation.yaml
+++ b/changelogs/fragments/netaddr_is_private_deprecation.yaml
@@ -3,3 +3,4 @@ minor_changes:
   - Use netaddr is_global() function instead of the deprecated is_private() function.
     (https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0)
   - Remove reserved IPv6 from integration test expected results.
+  - Set netaddr minimum version required to 0.10.1

--- a/plugins/plugin_utils/base/ipaddr_utils.py
+++ b/plugins/plugin_utils/base/ipaddr_utils.py
@@ -289,7 +289,7 @@ def _previous_usable_query(v, vtype):
 
 
 def _private_query(v, value):
-    if v.is_private():
+    if not v.ip.is_global():
         return value
 
 
@@ -298,7 +298,7 @@ def _public_query(v, value):
     if all(
         [
             v_ip.is_unicast(),
-            not v_ip.is_private(),
+            v_ip.is_global(),
             not v_ip.is_loopback(),
             not v_ip.is_netmask(),
             not v_ip.is_hostmask(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jsonschema
 textfsm
 ttp
 xmltodict
-netaddr==0.10.1
+netaddr>=0.10.1

--- a/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
@@ -28,7 +28,7 @@
 
 - name: Ipaddr filter with public network query
   ansible.builtin.set_fact:
-    result3: "{{ value | ansible.utils.ipaddr | ansible.utils.ipaddr('public') }}"
+    result3: "{{ value | ansible.utils.ipaddr('public') }}"
 
 - name: Assert result for ipaddr public network query
   ansible.builtin.assert:

--- a/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
@@ -20,7 +20,7 @@
 
 - name: Ipaddr filter with host string query
   ansible.builtin.set_fact:
-    result2: "{{ value | ansible.utils.ipaddr('host') }}"
+    result2: "{{ value | ansible.utils.ipaddr | ansible.utils.ipaddr('host') }}"
 
 - name: Assert result for ipaddr host query
   ansible.builtin.assert:

--- a/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/tasks/ipaddr.yaml
@@ -20,7 +20,7 @@
 
 - name: Ipaddr filter with host string query
   ansible.builtin.set_fact:
-    result2: "{{ value | ansible.utils.ipaddr | ansible.utils.ipaddr('host') }}"
+    result2: "{{ value | ansible.utils.ipaddr('host') }}"
 
 - name: Assert result for ipaddr host query
   ansible.builtin.assert:
@@ -28,7 +28,7 @@
 
 - name: Ipaddr filter with public network query
   ansible.builtin.set_fact:
-    result3: "{{ value | ansible.utils.ipaddr('public') }}"
+    result3: "{{ value | ansible.utils.ipaddr | ansible.utils.ipaddr('public') }}"
 
 - name: Assert result for ipaddr public network query
   ansible.builtin.assert:

--- a/tests/integration/targets/utils_ipaddr_filter/vars/main.yaml
+++ b/tests/integration/targets/utils_ipaddr_filter/vars/main.yaml
@@ -26,7 +26,6 @@ ipaddr_result2:
 
 ipaddr_result3:
   - 192.24.2.1
-  - 2001:db8:32c:faad::/64
 
 ipaddr_result4:
   - 192.168.32.0/24


### PR DESCRIPTION
##### SUMMARY

Fix: #331 

Netaddr has removed is_private method. This PR aims to fix it using is_global method instead that support both IPv4 and IPv6. 

First argument of [_private_query](https://github.com/ansible-collections/ansible.utils/blob/main/plugins/plugin_utils/base/ipaddr_utils.py#L291) is IPNetwork that's why `.ip (v.ip)` attribute is used. Otherwise `is_global` function is not available (see below for more infos).

Backward compatibility is maintained till netaddr 0.10.0. Not before.

Netaddr changelog: https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ipaddr_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Install netaddr > 1.0.0 and use `ansible.utils.ipaddr('private')` to reproduce.

Object attributes of `IPNetwork.ip` (only notable):

`'ipv4', 'ipv6', 'is_global', 'is_hostmask', 'is_ipv4_compat', 'is_ipv4_mapped', 'is_ipv4_private_use', 'is_ipv6_unique_local', 'is_link_local', 'is_loopback', 'is_multicast', 'is_netmask', 'is_reserved', 'is_unicast'`


Object attributes of `IPAddress` class (only notable):

`'ipv4', 'ipv6', 'is_global', 'is_hostmask', 'is_ipv4_compat', 'is_ipv4_mapped', 'is_ipv4_private_use', 'is_ipv6_unique_local', 'is_link_local', 'is_loopback', 'is_multicast', 'is_netmask', 'is_reserved', 'is_unicast'`