### PR TITLE
Fixes issue with keep_keys removing all keys when passed a dict.

### DIFF
--- a/changelogs/fragments/keep_keys.yaml
+++ b/changelogs/fragments/keep_keys.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - utils_keep_keys - Fixes issue where all keys are removed when data is passed in as a dict.

--- a/changelogs/fragments/keep_keys.yaml
+++ b/changelogs/fragments/keep_keys.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - utils_keep_keys - Fixes issue where all keys are removed when data is passed in as a dict.
+  - keep_keys - Fixes issue where all keys are removed when data is passed in as a dict.

--- a/plugins/plugin_utils/keep_keys.py
+++ b/plugins/plugin_utils/keep_keys.py
@@ -17,6 +17,7 @@ import re
 
 from ansible.errors import AnsibleFilterError
 
+
 def _raise_error(msg):
     """Raise an error message, prepend with filter name
     :param msg: The message

--- a/plugins/plugin_utils/keep_keys.py
+++ b/plugins/plugin_utils/keep_keys.py
@@ -17,7 +17,6 @@ import re
 
 from ansible.errors import AnsibleFilterError
 
-
 def _raise_error(msg):
     """Raise an error message, prepend with filter name
     :param msg: The message
@@ -35,13 +34,12 @@ def keep_keys_from_dict_n_list(data, target, matching_parameter):
     if isinstance(data, dict):
         keep = {}
         for k, val in data.items():
+            match = False
             for key in target:
-                match = None
                 if not isinstance(val, (list, dict)):
                     if matching_parameter == "regex":
-                        match = re.match(key, k)
-                        if match:
-                            keep[k] = val
+                        if re.match(key, k):
+                            keep[k], match = val, True
                     elif matching_parameter == "starts_with":
                         if k.startswith(key):
                             keep[k], match = val, True
@@ -53,13 +51,14 @@ def keep_keys_from_dict_n_list(data, target, matching_parameter):
                             keep[k], match = val, True
                 else:
                     list_data = keep_keys_from_dict_n_list(val, target, matching_parameter)
-                    if isinstance(list_data, list) and not match:
+                    if isinstance(list_data, list):
                         list_data = [r for r in list_data if r not in ([], {})]
-                        if all(isinstance(s, str) for s in list_data):
-                            continue
-                    if list_data in ([], {}):
-                        continue
-                    keep[k] = list_data
+                    if list_data not in ([], {}):
+                        keep[k], match = list_data, True
+            if not match and isinstance(val, (list, dict)):
+                nested_keep = keep_keys_from_dict_n_list(val, target, matching_parameter)
+                if nested_keep not in ([], {}):
+                    keep[k] = nested_keep
         return keep
     return data
 

--- a/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
+++ b/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
@@ -33,7 +33,7 @@
 - name: Assert result dicts
   ansible.builtin.assert:
     that:
-      - keep['starts_with'] == result['msg']
+      - keep_values['starts_with'] == result['msg']
 
 - name: Setup data as facts for equivalent
   ansible.builtin.set_fact:

--- a/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
+++ b/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
@@ -70,3 +70,27 @@
   ansible.builtin.assert:
     that:
       - keep_default['default'] == result['msg']
+
+- name: Setup data for multiple keys in dict
+  ansible.builtin.set_fact:
+    tomcat_data:
+      tomcat:
+        tomcat1:
+          name: tomcat1
+        tomcat2:
+          name: tomcat2
+        tomcat3:
+          name: tomcat3
+      tomcats_block:
+        - tomcat1
+        - tomcat2
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: "{{ tomcat_data | ansible.utils.keep_keys(target=['tomcats_block']) }}"
+  register: result
+
+- name: Assert result dicts
+  ansible.builtin.assert:
+    that:
+      - keep_tomcat['tomcat'] == result['msg']

--- a/tests/integration/targets/utils_keep_keys/vars/main.yaml
+++ b/tests/integration/targets/utils_keep_keys/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-keep:
+keep_values:
   starts_with:
     - interface_name: eth0
     - interface_name: eth1

--- a/tests/integration/targets/utils_keep_keys/vars/main.yaml
+++ b/tests/integration/targets/utils_keep_keys/vars/main.yaml
@@ -22,3 +22,9 @@ keep_default:
           is_enabled: true
     - interface_name: eth2
       is_enabled: false
+
+keep_tomcat:
+  tomcat:
+    tomcats_block:
+      - tomcat1
+      - tomcat2


### PR DESCRIPTION
##### SUMMARY
Fixes issue with keep_keys removing all keys when data is passed in as a dict

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`plugin_utils/keep_keys.py`

##### ADDITIONAL INFORMATION

Test playbook to verfiy:
```yaml
---
- name: Test
  hosts: localhost
  gather_facts: false
  vars:
    main_cat:
      tomcat:
        tomcat1:
          name: tomcat1
        tomcat2:
          name: tomcat2
        tomcat3:
          name: tomcat3
      tomcats_block:
        - tomcat1
        - tomcat2
  tasks:
    - name: remove keys
      ansible.builtin.debug:
        msg: "{{ main_cat | ansible.utils.remove_keys(target=['tomcats_block']) }}"
    - name: keep keys
      ansible.builtin.debug:
        msg: "{{ main_cat | ansible.utils.keep_keys(target=['tomcats_block']) }}"

```