### PR TITLE
 Fixed ansible.utils.ipaddr('host/prefix') function if size of subnet is 1

### DIFF
--- a/docs/docsite/rst/filters_ipaddr.rst
+++ b/docs/docsite/rst/filters_ipaddr.rst
@@ -857,7 +857,3 @@ the filter ``slaac()`` generates an IPv6 address for a given network and a MAC A
        Playbook organization by roles
    :ref:`playbooks_best_practices`
        Tips and tricks for playbooks
-   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
-       Have a question?  Stop by the google group!
-   :ref:`communication_irc`
-       How to join Ansible chat channels

--- a/plugins/plugin_utils/base/ipaddr_utils.py
+++ b/plugins/plugin_utils/base/ipaddr_utils.py
@@ -100,8 +100,15 @@ def _ip_query(v):
 
 
 def _address_prefix_query(v):
+    # Handle single IP address case
     if v.size == 1:
-        return False
+        # For IPv4, return False for a single IP without a /32 prefix
+        if v.version == 4 and v.prefixlen != 32:
+            return False
+        # For IPv6, return False for a single IP without a /128 prefix
+        if v.version == 6 and v.prefixlen != 128:
+            return False
+
     if v.size > 2 and v.ip in (v.network, v.broadcast):
         return False
     return str(v.ip) + "/" + str(v.prefixlen)

--- a/plugins/plugin_utils/base/ipaddr_utils.py
+++ b/plugins/plugin_utils/base/ipaddr_utils.py
@@ -100,7 +100,9 @@ def _ip_query(v):
 
 
 def _address_prefix_query(v):
-    if v.ip in (v.network, v.broadcast):
+    if v.size == 1:
+        return False
+    if v.size > 2 and v.ip in (v.network, v.broadcast):
         return False
     return str(v.ip) + "/" + str(v.prefixlen)
 

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -270,6 +270,22 @@ class TestIpFilter(TestCase):
         self.assertEqual(ipaddr(address, "range_usable"), "1.12.1.1-1.12.1.254")
 
     def test_address_prefix(self):
+        # Single IP address without a prefix, should return empty
+        address = "203.0.113.23"
+        self.assertFalse(ipaddr(address, "address/prefix"))
+    
+        # Single IP address with /32, should return address with /32
+        address_with_prefix = "203.0.113.23/32"
+        self.assertEqual(ipaddr(address_with_prefix, "address/prefix"), address_with_prefix)
+    
+        # Valid /24 network range, should return the address and prefix
+        network_address = "203.0.113.0/24"
+        self.assertEqual(ipaddr(network_address, "address/prefix"), network_address)
+    
+        # Broadcast address of /24, should return False
+        broadcast_address = "203.0.113.255/24"
+        self.assertFalse(ipaddr(broadcast_address, "address/prefix"))
+        
         # Regular address
         address = "1.12.1.12/24"
         self.assertEqual(ipaddr(address, "address/prefix"), address)

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -273,19 +273,19 @@ class TestIpFilter(TestCase):
         # Single IP address without a prefix, should return empty
         address = "203.0.113.23"
         self.assertFalse(ipaddr(address, "address/prefix"))
-    
+
         # Single IP address with /32, should return address with /32
         address_with_prefix = "203.0.113.23/32"
         self.assertEqual(ipaddr(address_with_prefix, "address/prefix"), address_with_prefix)
-    
+
         # Valid /24 network range, should return the address and prefix
         network_address = "203.0.113.0/24"
         self.assertEqual(ipaddr(network_address, "address/prefix"), network_address)
-    
+
         # Broadcast address of /24, should return False
         broadcast_address = "203.0.113.255/24"
         self.assertFalse(ipaddr(broadcast_address, "address/prefix"))
-        
+
         # Regular address
         address = "1.12.1.12/24"
         self.assertEqual(ipaddr(address, "address/prefix"), address)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/ansible.utils/issues/372

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible.utils.ipaddr

##### ADDITIONAL INFORMATION

If non CIDR IP is given to  ansible.utils.ipaddr('host/prefix') function is not returning False value.
e.g
```
 "192.168.0.21" | ansible.utils.ipaddr('host/prefix')
```
Ideally above code should return False value.  Hence corrected the behavior.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- name: Validate IP address in CIDR notation
  hosts: localhost
  gather_facts: no
  vars:
    # Replace this with your actual IP address in CIDR notation
    host_ip_cidr: "2620:128:f021:9028::112"  # Can be IPV4

  tasks:
    - name: Check if the IP address in CIDR notation is valid
      assert:
        that:
          - host_ip_cidr | ansible.utils.ipaddr('host/prefix')
        msg: "Invalid IP address in CIDR notation. Enter a valid IP address in CIDR notation. For example, 192.168.0.2/24 or 2001::1/64."

    - name: Output the validation result
      debug:
        msg: "The IP address {{ host_ip_cidr }} is valid in CIDR notation."

```
if we run above playbook before my change, then playbook passes
```
# Before my change
ansible-playbook a.yml
------------------------------------------------------------------------------------------------------------------------------
Log Path:                                                             /var/log/ansible/PLAYBOOK/2024-09-10T16-15-20.093922.log
Configuring:                                                                                                             100%
``` 

After my change playbook fails as expected.
```
ansible-playbook a.yml
------------------------------------------------------------------------------------------------------------------------------
Log Path:                                                             /var/log/ansible/PLAYBOOK/2024-09-10T16-16-00.069168.log
Configuring:                                                                                                               0%

Task Name: Check if the IP address in CIDR notation is valid
Error:
 "Invalid IP address in CIDR notation. Enter a valid IP address in CIDR notation. For example, 192.168.0.2/24 or 2001::1/64."
```

