### PR TITLE
Fixes keep_keys filter to retain the entire node when a key match occurs, rather than just the leaf node values.

### DIFF
--- a/changelogs/fragments/keep_keys_greedy.yaml
+++ b/changelogs/fragments/keep_keys_greedy.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - keep_keys - Fixes keep_keys filter to retain the entire node when a key match occurs, rather than just the leaf node values.

--- a/plugins/plugin_utils/keep_keys.py
+++ b/plugins/plugin_utils/keep_keys.py
@@ -37,7 +37,9 @@ def keep_keys_from_dict_n_list(data, target, matching_parameter):
         for k, val in data.items():
             match = False
             for key in target:
-                if not isinstance(val, (list, dict)):
+                if k == key:
+                    keep[k], match = val, True
+                elif not isinstance(val, (list, dict)):
                     if matching_parameter == "regex":
                         if re.match(key, k):
                             keep[k], match = val, True

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,0 +1,2 @@
+[testgroup]
+testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/home/roverflow/workspace/virtualvenvs/a216p312/bin/python"

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,2 +1,0 @@
-[testgroup]
-testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/home/roverflow/workspace/virtualvenvs/a216p312/bin/python"

--- a/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
+++ b/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
@@ -79,12 +79,19 @@
           name: tomcat1
         tomcat2:
           name: tomcat2
+          tomcat3:
+            name: tomcat3
         tomcat3:
           name: tomcat3
+        tomcat4:
+          name: tomcat3
+          tomcat3:
+            tomcat3:
+              name: tomcattest
+            checktomcat3: stringinput
       tomcats_block:
         - tomcat1
         - tomcat2
-
 - name: Debug
   ansible.builtin.debug:
     msg: "{{ tomcat_data | ansible.utils.keep_keys(target=['tomcats_block']) }}"
@@ -104,3 +111,13 @@
   ansible.builtin.assert:
     that:
       - keep_tomcat['greedy_values'] == result['msg']
+
+- name: Test to keep keys to check if nested dict is matched
+  ansible.builtin.debug:
+    msg: "{{ tomcat_data['tomcat'] | ansible.utils.keep_keys(target=['tomcat3']) }}"
+  register: result
+
+- name: Assert result dicts
+  ansible.builtin.assert:
+    that:
+      - keep_tomcat['nested_values'] == result['msg']

--- a/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
+++ b/tests/integration/targets/utils_keep_keys/tasks/simple.yaml
@@ -94,3 +94,13 @@
   ansible.builtin.assert:
     that:
       - keep_tomcat['tomcat'] == result['msg']
+
+- name: Test to keep keys when initial node is matched
+  ansible.builtin.debug:
+    msg: "{{ tomcat_data['tomcat'] | ansible.utils.keep_keys(target=['tomcat1', 'tomcat2']) }}"
+  register: result
+
+- name: Assert result dicts
+  ansible.builtin.assert:
+    that:
+      - keep_tomcat['greedy_values'] == result['msg']

--- a/tests/integration/targets/utils_keep_keys/vars/main.yaml
+++ b/tests/integration/targets/utils_keep_keys/vars/main.yaml
@@ -28,3 +28,8 @@ keep_tomcat:
     tomcats_block:
       - tomcat1
       - tomcat2
+  greedy_values:
+    tomcat1:
+      name: tomcat1
+    tomcat2:
+      name: tomcat2

--- a/tests/integration/targets/utils_keep_keys/vars/main.yaml
+++ b/tests/integration/targets/utils_keep_keys/vars/main.yaml
@@ -33,3 +33,16 @@ keep_tomcat:
       name: tomcat1
     tomcat2:
       name: tomcat2
+      tomcat3:
+        name: tomcat3
+  nested_values:
+    tomcat2:
+      tomcat3:
+        name: tomcat3
+    tomcat3:
+      name: tomcat3
+    tomcat4:
+      tomcat3:
+        tomcat3:
+          name: tomcattest
+        checktomcat3: stringinput


### PR DESCRIPTION
##### SUMMARY
Fixes keep_keys filter to retain the entire node when a key match occurs, rather than just the leaf node values.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
- `utils_keep_keys`

##### ADDITIONAL INFORMATION
Playbook to verify

```yaml
---
- name: Test
  hosts: localhost
  gather_facts: false

  vars:
    tomcat:
      tomcat1:
        name: tomcat1
      tomcat2:
        name: tomcat2
      tomcat3:
        name: asdasd
  tasks:
    - name: keep keys
      ansible.builtin.debug:
        msg: "{{ tomcat | ansible.utils.keep_keys(target=['tomcat1', 'tomcat2']) }}"
    - name: keep keys
      ansible.builtin.debug:
        msg: "{{ tomcat | ansible.utils.remove_keys(target=['tomcat3']) }}"
```

Output to expect
```sh
PLAY [Test] *******************************************************************************************

TASK [keep keys] **************************************************************************************
ok: [localhost] => 
  msg:
    tomcat1:
      name: tomcat1
    tomcat2:
      name: tomcat2

TASK [keep keys] **************************************************************************************
ok: [localhost] => 
  msg:
    tomcat1:
      name: tomcat1
    tomcat2:
      name: tomcat2

```