### PR TITLE
Fixes tests that use AnsibleUndefined

### DIFF
--- a/changelogs/fragments/test_ansibleundefined.yaml
+++ b/changelogs/fragments/test_ansibleundefined.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fixes test cases where there were assertion failure due to AnsibleUndefined path being changed.

--- a/tests/unit/plugins/filter/test_ipaddr.py
+++ b/tests/unit/plugins/filter/test_ipaddr.py
@@ -70,7 +70,8 @@ class TestIpFilter(TestCase):
         args = ["", AnsibleUndefined(name="my_ip"), ""]
         with pytest.raises(
             AnsibleFilterError,
-            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipaddr filter <value>",
+            # Note: this class has been moved to native_helpers dir since 2.16, hence adding regex to be backwards compatable with 2.15
+            match=r"Unrecognized type <<class 'ansible\.template\.(native_helpers\.)?AnsibleUndefined'>> for ipaddr filter <value>",
         ):
             _ipaddr(*args)
 

--- a/tests/unit/plugins/filter/test_ipv4.py
+++ b/tests/unit/plugins/filter/test_ipv4.py
@@ -50,7 +50,8 @@ class TestIp4(TestCase):
         args = ["", AnsibleUndefined(name="my_ip"), ""]
         with pytest.raises(
             AnsibleFilterError,
-            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv4 filter <value>",
+            # Note: this class has been moved to native_helpers dir since 2.16, hence adding regex to be backwards compatable with 2.15
+            match=r"Unrecognized type <<class 'ansible\.template\.(native_helpers\.)?AnsibleUndefined'>> for ipv4 filter <value>",
         ):
             _ipv4(*args)
 

--- a/tests/unit/plugins/filter/test_ipv6.py
+++ b/tests/unit/plugins/filter/test_ipv6.py
@@ -53,7 +53,8 @@ class TestIp6(TestCase):
         args = ["", AnsibleUndefined(name="my_ip"), ""]
         with pytest.raises(
             AnsibleFilterError,
-            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipv6 filter <value>",
+            # Note: this class has been moved to native_helpers dir since 2.16, hence adding regex to be backwards compatable with 2.15
+            match=r"Unrecognized type <<class 'ansible\.template\.(native_helpers\.)?AnsibleUndefined'>> for ipv6 filter <value>",
         ):
             _ipv6(*args)
 

--- a/tests/unit/plugins/filter/test_ipwrap.py
+++ b/tests/unit/plugins/filter/test_ipwrap.py
@@ -55,7 +55,8 @@ class TestIpWrap(TestCase):
         args = ["", AnsibleUndefined(name="my_ip"), ""]
         with pytest.raises(
             AnsibleFilterError,
-            match="Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipwrap filter <value>",
+            # Note: this class has been moved to native_helpers dir since 2.16, hence adding regex to be backwards compatable with 2.15
+            match=r"Unrecognized type <<class 'ansible\.template\.(native_helpers\.)?AnsibleUndefined'>> for ipwrap filter <value>",
         ):
             _ipwrap(*args)
 


### PR DESCRIPTION
##### SUMMARY
Fixes tests that use AnsibleUndefined - this class has been moved to native_helpers dir since 2.16, hence adding regex to be backwards compatable with 2.15

##### ISSUE TYPE
- Test fix
