### PR TITLE
Update minimum ansible_required to 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more information about communication, see the [Ansible communication guide](
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15.0**.
+This collection has been tested against following Ansible versions: **>=2.16.0**.
 
 For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
 fully qualified collection name (for example, `cisco.ios.ios`).

--- a/changelogs/fragments/bump_216.yaml
+++ b/changelogs/fragments/bump_216.yaml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - Bumping `requires_ansible` to `>=2.16.0`, since previous ansible-core versions are EoL now.

--- a/changelogs/fragments/bump_216.yaml
+++ b/changelogs/fragments/bump_216.yaml
@@ -1,3 +1,6 @@
 ---
+release_summary: >
+  With this release, the minimum required version of `ansible-core` for this collection is `2.16.0`.
+  The last version known to be compatible with `ansible-core` versions below `2.16` is v5.1.2.
 major_changes:
   - Bumping `requires_ansible` to `>=2.16.0`, since previous ansible-core versions are EoL now.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.9"
+  python_requires: ">=3.10"


### PR DESCRIPTION
##### SUMMARY
This bumps the minimum required ansible version to 2.16