### PR TITLE
Fix description of return value of reduce_on_network

### DIFF
--- a/docs/ansible.utils.reduce_on_network_filter.rst
+++ b/docs/ansible.utils.reduce_on_network_filter.rst
@@ -120,7 +120,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 </td>
                 <td></td>
                 <td>
-                            <div>Returns whether an address or a network passed as argument is in a network.</div>
+                            <div>Returns the filtered list of addresses belonging to the network.</div>
                     <br/>
                 </td>
             </tr>


### PR DESCRIPTION
##### SUMMARY
The current description of the return value of `reduce_on_network` looks like a copy-paste error from a different filter

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`reduce_on_network_filter`