### PR TITLE
Fix spelling error in resolveable

### DIFF
--- a/changelogs/fragments/fix_description.yaml
+++ b/changelogs/fragments/fix_description.yaml
@@ -1,3 +1,4 @@
 ---
 doc_changes:
   - Fix the description of the reduce_on_network filter.
+  - Fix the synopsis of the resolveable test.

--- a/docs/ansible.utils.resolvable_test.rst
+++ b/docs/ansible.utils.resolvable_test.rst
@@ -17,7 +17,7 @@ Version added: 2.2.0
 
 Synopsis
 --------
-- This plugin checks if the provided IP address of host name can be resolved using /etc/hosts or DNS
+- This plugin checks if the provided IP address or host name can be resolved using /etc/hosts or DNS
 
 
 

--- a/plugins/test/resolvable.py
+++ b/plugins/test/resolvable.py
@@ -31,7 +31,7 @@ DOCUMENTATION = """
     version_added: "2.2.0"
     short_description: Test if an IP or name can be resolved via /etc/hosts or DNS
     description:
-        - This plugin checks if the provided IP address of host name can be resolved using /etc/hosts or DNS
+        - This plugin checks if the provided IP address or host name can be resolved using /etc/hosts or DNS
     options:
         host:
             description:


### PR DESCRIPTION
##### SUMMARY
This PR fixes a tiny spelling error in the ansible.utils.resolvable test.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
resolveable

##### ADDITIONAL INFORMATION
Changed the word "of" to "or" in the docs for the test:
"This plugin checks if the provided IP address **_of_** host name can be resolved using /etc/hosts or DNS"
