### PR TITLE
Add cidr_allocate module for CIDR block allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Name | Description
 ### Modules
 Name | Description
 --- | ---
+[ansible.utils.cidr_allocate](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.cidr_allocate_module.rst)|Allocate available CIDR blocks from a master range
 [ansible.utils.cli_parse](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.cli_parse_module.rst)|Parse cli output or text using a variety of parsers
 [ansible.utils.fact_diff](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.fact_diff_module.rst)|Find the difference between currently set facts
 [ansible.utils.update_fact](https://github.com/ansible-collections/ansible.utils/blob/main/docs/ansible.utils.update_fact_module.rst)|Update currently set facts

--- a/plugins/modules/cidr_allocate.py
+++ b/plugins/modules/cidr_allocate.py
@@ -1,0 +1,398 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: cidr_allocate
+author: Jonathan Springer (@jonpspri)
+version_added: "6.1.0"
+short_description: Allocate available CIDR blocks from a master range
+description:
+    - Finds and allocates one or more available CIDR blocks of a specified size within a master CIDR range.
+    - Avoids conflicts with already-allocated CIDR blocks.
+    - Uses a best-fit algorithm to efficiently utilize the address space by preferring the smallest available gap.
+    - Can allocate multiple non-overlapping CIDR blocks in a single call.
+options:
+    master_cidr:
+        description:
+            - The master CIDR range from which to allocate (e.g., '172.16.0.0/12').
+        required: true
+        type: str
+    used_cidrs:
+        description:
+            - List of CIDR blocks that are already in use and should be avoided.
+            - Can be of varying prefix lengths.
+        required: false
+        type: list
+        elements: str
+        default: []
+    prefix_length:
+        description:
+            - The desired prefix length for the new CIDR block(s) (e.g., 24 for a /24 network).
+            - Must be >= the master CIDR's prefix length and <= 32.
+        required: true
+        type: int
+    count:
+        description:
+            - The number of CIDR ranges to allocate.
+            - Each range will be allocated using the best-fit algorithm.
+            - Each allocation considers previously allocated ranges in the same call.
+        required: false
+        type: int
+        default: 1
+notes:
+    - This module uses a best-fit algorithm to find the smallest available gap that can accommodate the requested CIDR block.
+    - The allocated CIDR blocks will be properly aligned on network boundaries.
+    - If insufficient blocks are available, the module will fail with an error message.
+    - When allocating multiple blocks, each successive allocation treats previous allocations as used.
+"""
+
+EXAMPLES = r"""
+# Allocate a single /24 network from a master /12 range
+- name: Allocate single CIDR block
+  cidr_allocate:
+    master_cidr: '172.16.0.0/12'
+    prefix_length: 24
+    used_cidrs: []
+  register: cidr_result
+
+- name: Show allocated CIDR
+  debug:
+    msg: "{{ cidr_result.allocated_cidrs }}"
+
+# Allocate a /24 avoiding already-used blocks
+- name: Allocate CIDR block with exclusions
+  cidr_allocate:
+    master_cidr: '172.16.0.0/12'
+    prefix_length: 24
+    used_cidrs:
+      - '172.16.0.0/16'
+      - '172.17.0.0/16'
+      - '172.18.5.0/24'
+  register: cidr_result
+
+# Allocate multiple CIDR blocks at once
+- name: Allocate 3 /24 networks
+  cidr_allocate:
+    master_cidr: '10.0.0.0/8'
+    prefix_length: 24
+    count: 3
+    used_cidrs: "{{ existing_cidrs }}"
+  register: cidr_result
+
+- name: Use the allocated CIDRs
+  debug:
+    msg: "Allocated CIDRs: {{ cidr_result.allocated_cidrs }}"
+"""
+
+RETURN = r"""
+allocated_cidrs:
+    description:
+        - List of allocated CIDR blocks in standard notation (e.g., ['172.16.5.0/24'])
+        - Will contain one element if count=1, or multiple elements if count > 1
+    type: list
+    elements: str
+    returned: always
+count:
+    description:
+        - The number of CIDR blocks that were allocated
+    type: int
+    returned: always
+"""
+
+import ipaddress
+from ansible.module_utils.basic import AnsibleModule
+
+
+class CIDRAllocator:
+    """
+    Handles the logic for finding and allocating available CIDR blocks.
+    Uses a best-fit algorithm to minimize address space fragmentation.
+    """
+
+    def __init__(self, master_cidr, used_cidrs, prefix_length):
+        """
+        Initialize the CIDR allocator.
+
+        Args:
+            master_cidr: String representation of the master CIDR (e.g., '172.16.0.0/12')
+            used_cidrs: List of already-allocated CIDR strings
+            prefix_length: Desired prefix length for the new allocation (e.g., 24)
+        """
+        try:
+            self.master_network = ipaddress.ip_network(master_cidr, strict=False)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Invalid master CIDR '{master_cidr}': {str(e)}")
+
+        self.prefix_length = prefix_length
+        self.used_networks = []
+
+        # Validate prefix length
+        if not isinstance(prefix_length, int):
+            raise ValueError(f"prefix_length must be an integer, got {type(prefix_length).__name__}")
+
+        if prefix_length < self.master_network.prefixlen:
+            raise ValueError(
+                f"Requested prefix length ({prefix_length}) is smaller than master CIDR "
+                f"prefix length ({self.master_network.prefixlen})"
+            )
+
+        if prefix_length > 32:
+            raise ValueError(f"Requested prefix length ({prefix_length}) must be <= 32")
+
+        # Parse and validate used CIDRs
+        for cidr in used_cidrs:
+            try:
+                network = ipaddress.ip_network(cidr, strict=False)
+                # Only include networks that overlap with master range
+                if self._networks_overlap(network, self.master_network):
+                    self.used_networks.append(network)
+            except (ValueError, TypeError) as e:
+                raise ValueError(f"Invalid CIDR in used_cidrs '{cidr}': {str(e)}")
+
+        # Sort used networks by starting address for easier gap finding
+        self.used_networks.sort(key=lambda net: net.network_address)
+
+    def _networks_overlap(self, net1, net2):
+        """Check if two networks overlap."""
+        return net1.overlaps(net2)
+
+    def _merge_overlapping_ranges(self):
+        """
+        Merge overlapping or adjacent used networks into contiguous ranges.
+        Returns a list of (start_int, end_int) tuples representing used IP ranges.
+        """
+        if not self.used_networks:
+            return []
+
+        # Convert networks to integer ranges
+        ranges = []
+        for network in self.used_networks:
+            start = int(network.network_address)
+            end = int(network.broadcast_address)
+            ranges.append((start, end))
+
+        # Merge overlapping ranges
+        merged = []
+        current_start, current_end = ranges[0]
+
+        for start, end in ranges[1:]:
+            if start <= current_end + 1:  # Overlapping or adjacent
+                current_end = max(current_end, end)
+            else:
+                merged.append((current_start, current_end))
+                current_start, current_end = start, end
+
+        merged.append((current_start, current_end))
+        return merged
+
+    def _find_available_gaps(self):
+        """
+        Find all gaps (unused ranges) in the master CIDR.
+        Returns a list of (start_int, end_int) tuples.
+        """
+        master_start = int(self.master_network.network_address)
+        master_end = int(self.master_network.broadcast_address)
+
+        used_ranges = self._merge_overlapping_ranges()
+        gaps = []
+
+        # Check for gap before first used range
+        if not used_ranges:
+            gaps.append((master_start, master_end))
+            return gaps
+
+        if used_ranges[0][0] > master_start:
+            gaps.append((master_start, used_ranges[0][0] - 1))
+
+        # Check for gaps between used ranges
+        for i in range(len(used_ranges) - 1):
+            gap_start = used_ranges[i][1] + 1
+            gap_end = used_ranges[i + 1][0] - 1
+            if gap_start <= gap_end:
+                gaps.append((gap_start, gap_end))
+
+        # Check for gap after last used range
+        if used_ranges[-1][1] < master_end:
+            gaps.append((used_ranges[-1][1] + 1, master_end))
+
+        return gaps
+
+    def _find_aligned_cidr_in_gap(self, gap_start, gap_end):
+        """
+        Find a properly-aligned CIDR block of the desired prefix length within a gap.
+
+        Args:
+            gap_start: Starting IP address (as integer) of the gap
+            gap_end: Ending IP address (as integer) of the gap
+
+        Returns:
+            ipaddress.IPv4Network object if found, None otherwise
+        """
+        # Calculate the size of the network we want to allocate
+        network_size = 2 ** (32 - self.prefix_length)
+
+        # Find the alignment requirement (CIDR blocks must start on specific boundaries)
+        alignment = network_size
+
+        # Find the first aligned address >= gap_start
+        aligned_start = gap_start
+        if gap_start % alignment != 0:
+            aligned_start = ((gap_start // alignment) + 1) * alignment
+
+        # Check if the aligned network fits in the gap
+        aligned_end = aligned_start + network_size - 1
+
+        if aligned_end <= gap_end:
+            # Create and return the network
+            network_addr = ipaddress.IPv4Address(aligned_start)
+            return ipaddress.ip_network(f"{network_addr}/{self.prefix_length}", strict=False)
+
+        return None
+
+    def allocate_single(self):
+        """
+        Find and return a single available CIDR block using best-fit algorithm.
+
+        Returns:
+            String representation of the allocated CIDR block
+
+        Raises:
+            ValueError if no suitable block can be found
+        """
+        gaps = self._find_available_gaps()
+
+        if not gaps:
+            raise ValueError(
+                f"No available address space in master CIDR {self.master_network}. "
+                f"All addresses are allocated."
+            )
+
+        # For each gap, try to find a valid CIDR allocation
+        # Store tuples of (gap_size, cidr_network, gap_info) for best-fit selection
+        candidates = []
+
+        for gap_start, gap_end in gaps:
+            cidr = self._find_aligned_cidr_in_gap(gap_start, gap_end)
+            if cidr:
+                gap_size = gap_end - gap_start + 1
+                candidates.append((gap_size, cidr, (gap_start, gap_end)))
+
+        if not candidates:
+            # Calculate how much space we need
+            needed_size = 2 ** (32 - self.prefix_length)
+            gap_descriptions = [
+                "{0}-{1} ({2} addresses)".format(
+                    ipaddress.IPv4Address(s), ipaddress.IPv4Address(e), e - s + 1
+                )
+                for s, e in gaps
+            ]
+            raise ValueError(
+                f"Cannot allocate /{self.prefix_length} network in {self.master_network}. "
+                f"No suitable gaps found. Need {needed_size} contiguous addresses. "
+                f"Available gaps: {gap_descriptions}"
+            )
+
+        # Sort by gap size (smallest first) for best-fit algorithm
+        candidates.sort(key=lambda x: x[0])
+
+        # Return the CIDR from the smallest gap
+        best_cidr = candidates[0][1]
+        return str(best_cidr)
+
+    def allocate_multiple(self, count):
+        """
+        Allocate multiple non-overlapping CIDR blocks.
+
+        Args:
+            count: Number of CIDR blocks to allocate
+
+        Returns:
+            List of allocated CIDR block strings
+
+        Raises:
+            ValueError if the requested count cannot be satisfied
+        """
+        allocated = []
+
+        for i in range(count):
+            try:
+                cidr = self.allocate_single()
+                allocated.append(cidr)
+                # Add the newly allocated CIDR to used_networks for next iteration
+                network = ipaddress.ip_network(cidr, strict=False)
+                self.used_networks.append(network)
+                # Re-sort used networks
+                self.used_networks.sort(key=lambda net: net.network_address)
+            except ValueError as e:
+                raise ValueError(
+                    f"Could only allocate {len(allocated)} of {count} requested CIDR blocks. "
+                    f"Error: {str(e)}"
+                )
+
+        return allocated
+
+
+def run_module():
+    """
+    Main module execution.
+    """
+    # Define module arguments
+    module_args = dict(
+        master_cidr=dict(type='str', required=True),
+        used_cidrs=dict(type='list', elements='str', default=[]),
+        prefix_length=dict(type='int', required=True),
+        count=dict(type='int', default=1),
+    )
+
+    # Initialize module
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # Get parameters
+    master_cidr = module.params['master_cidr']
+    used_cidrs = module.params['used_cidrs']
+    prefix_length = module.params['prefix_length']
+    count = module.params['count']
+
+    # Validate count
+    if count < 1:
+        module.fail_json(msg=f"count must be at least 1, got {count}")
+
+    try:
+        # Create allocator and find available CIDRs
+        allocator = CIDRAllocator(master_cidr, used_cidrs, prefix_length)
+
+        if count == 1:
+            allocated_cidrs = [allocator.allocate_single()]
+        else:
+            allocated_cidrs = allocator.allocate_multiple(count)
+
+        # Return success with allocated CIDRs
+        module.exit_json(
+            changed=False,  # This is a read-only operation
+            allocated_cidrs=allocated_cidrs,
+            count=len(allocated_cidrs)
+        )
+
+    except ValueError as e:
+        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=f"Unexpected error: {str(e)}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cidr_allocate.py
+++ b/plugins/modules/cidr_allocate.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 DOCUMENTATION = r"""
@@ -108,6 +109,7 @@ count:
 """
 
 import ipaddress
+
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -136,12 +138,14 @@ class CIDRAllocator:
 
         # Validate prefix length
         if not isinstance(prefix_length, int):
-            raise ValueError(f"prefix_length must be an integer, got {type(prefix_length).__name__}")
+            raise ValueError(
+                f"prefix_length must be an integer, got {type(prefix_length).__name__}"
+            )
 
         if prefix_length < self.master_network.prefixlen:
             raise ValueError(
                 f"Requested prefix length ({prefix_length}) is smaller than master CIDR "
-                f"prefix length ({self.master_network.prefixlen})"
+                f"prefix length ({self.master_network.prefixlen})",
             )
 
         if prefix_length > 32:
@@ -272,7 +276,7 @@ class CIDRAllocator:
         if not gaps:
             raise ValueError(
                 f"No available address space in master CIDR {self.master_network}. "
-                f"All addresses are allocated."
+                f"All addresses are allocated.",
             )
 
         # For each gap, try to find a valid CIDR allocation
@@ -290,14 +294,16 @@ class CIDRAllocator:
             needed_size = 2 ** (32 - self.prefix_length)
             gap_descriptions = [
                 "{0}-{1} ({2} addresses)".format(
-                    ipaddress.IPv4Address(s), ipaddress.IPv4Address(e), e - s + 1
+                    ipaddress.IPv4Address(s),
+                    ipaddress.IPv4Address(e),
+                    e - s + 1,
                 )
                 for s, e in gaps
             ]
             raise ValueError(
                 f"Cannot allocate /{self.prefix_length} network in {self.master_network}. "
                 f"No suitable gaps found. Need {needed_size} contiguous addresses. "
-                f"Available gaps: {gap_descriptions}"
+                f"Available gaps: {gap_descriptions}",
             )
 
         # Sort by gap size (smallest first) for best-fit algorithm
@@ -334,7 +340,7 @@ class CIDRAllocator:
             except ValueError as e:
                 raise ValueError(
                     f"Could only allocate {len(allocated)} of {count} requested CIDR blocks. "
-                    f"Error: {str(e)}"
+                    f"Error: {str(e)}",
                 )
 
         return allocated
@@ -346,23 +352,23 @@ def run_module():
     """
     # Define module arguments
     module_args = dict(
-        master_cidr=dict(type='str', required=True),
-        used_cidrs=dict(type='list', elements='str', default=[]),
-        prefix_length=dict(type='int', required=True),
-        count=dict(type='int', default=1),
+        master_cidr=dict(type="str", required=True),
+        used_cidrs=dict(type="list", elements="str", default=[]),
+        prefix_length=dict(type="int", required=True),
+        count=dict(type="int", default=1),
     )
 
     # Initialize module
     module = AnsibleModule(
         argument_spec=module_args,
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     # Get parameters
-    master_cidr = module.params['master_cidr']
-    used_cidrs = module.params['used_cidrs']
-    prefix_length = module.params['prefix_length']
-    count = module.params['count']
+    master_cidr = module.params["master_cidr"]
+    used_cidrs = module.params["used_cidrs"]
+    prefix_length = module.params["prefix_length"]
+    count = module.params["count"]
 
     # Validate count
     if count < 1:
@@ -381,7 +387,7 @@ def run_module():
         module.exit_json(
             changed=False,  # This is a read-only operation
             allocated_cidrs=allocated_cidrs,
-            count=len(allocated_cidrs)
+            count=len(allocated_cidrs),
         )
 
     except ValueError as e:
@@ -394,5 +400,5 @@ def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/integration/targets/utils_cidr_allocate/tasks/errors.yml
+++ b/tests/integration/targets/utils_cidr_allocate/tasks/errors.yml
@@ -1,0 +1,72 @@
+---
+- name: "Errors: Attempt allocation with invalid master_cidr"
+  ansible.utils.cidr_allocate:
+    master_cidr: "not-a-valid-cidr"
+    prefix_length: 24
+    used_cidrs: []
+  register: invalid_master_result
+  ignore_errors: true
+
+- name: "Errors: Assert invalid master_cidr fails"
+  ansible.builtin.assert:
+    that:
+      - invalid_master_result is failed
+      - "'Invalid master CIDR' in invalid_master_result.msg"
+
+- name: "Errors: Attempt allocation with prefix_length smaller than master"
+  ansible.utils.cidr_allocate:
+    master_cidr: "10.0.0.0/16"
+    prefix_length: 8
+    used_cidrs: []
+  register: small_prefix_result
+  ignore_errors: true
+
+- name: "Errors: Assert prefix_length too small fails"
+  ansible.builtin.assert:
+    that:
+      - small_prefix_result is failed
+      - "'smaller than master CIDR prefix length' in small_prefix_result.msg"
+
+- name: "Errors: Attempt allocation with prefix_length > 32"
+  ansible.utils.cidr_allocate:
+    master_cidr: "10.0.0.0/8"
+    prefix_length: 33
+    used_cidrs: []
+  register: large_prefix_result
+  ignore_errors: true
+
+- name: "Errors: Assert prefix_length > 32 fails"
+  ansible.builtin.assert:
+    that:
+      - large_prefix_result is failed
+      - "'must be <= 32' in large_prefix_result.msg"
+
+- name: "Errors: Attempt allocation with exhausted address space"
+  ansible.utils.cidr_allocate:
+    master_cidr: "10.0.0.0/24"
+    prefix_length: 28
+    used_cidrs:
+      - "10.0.0.0/24"
+  register: exhausted_result
+  ignore_errors: true
+
+- name: "Errors: Assert exhausted space fails"
+  ansible.builtin.assert:
+    that:
+      - exhausted_result is failed
+      - "'No available address space' in exhausted_result.msg"
+
+- name: "Errors: Attempt to allocate more blocks than available"
+  ansible.utils.cidr_allocate:
+    master_cidr: "10.0.0.0/24"
+    prefix_length: 24
+    count: 2
+    used_cidrs: []
+  register: overcount_result
+  ignore_errors: true
+
+- name: "Errors: Assert over-allocation fails"
+  ansible.builtin.assert:
+    that:
+      - overcount_result is failed
+      - "'Could only allocate' in overcount_result.msg"

--- a/tests/integration/targets/utils_cidr_allocate/tasks/main.yaml
+++ b/tests/integration/targets/utils_cidr_allocate/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+- name: Recursively find all test files
+  ansible.builtin.find:
+    file_type: file
+    paths: "{{ role_path }}/tasks"
+    recurse: false
+    use_regex: true
+    patterns:
+      - "^(?!_|main).+$"
+  delegate_to: localhost
+  register: found
+
+- name: Include tasks
+  ansible.builtin.include_tasks: "{{ item.path }}"
+  loop: "{{ found.files }}"

--- a/tests/integration/targets/utils_cidr_allocate/tasks/multiple.yml
+++ b/tests/integration/targets/utils_cidr_allocate/tasks/multiple.yml
@@ -1,0 +1,45 @@
+---
+- name: "Multiple: Allocate 3 /24 networks"
+  ansible.utils.cidr_allocate:
+    master_cidr: "{{ multi_master_cidr }}"
+    prefix_length: "{{ multi_prefix_length }}"
+    count: "{{ multi_count }}"
+    used_cidrs: []
+  register: multi_result
+
+- name: "Multiple: Verify correct count returned"
+  ansible.builtin.assert:
+    that:
+      - multi_result is success
+      - multi_result.count == multi_count
+      - multi_result.allocated_cidrs | length == multi_count
+
+- name: "Multiple: Verify all results are unique"
+  ansible.builtin.assert:
+    that:
+      - multi_result.allocated_cidrs | unique | length == multi_count
+
+- name: "Multiple: Verify all CIDRs are within master range"
+  ansible.builtin.assert:
+    that:
+      - cidr | ansible.utils.ipaddr('network') != false
+    msg: "{{ cidr }} is not a valid network"
+  loop: "{{ multi_result.allocated_cidrs }}"
+  loop_control:
+    loop_var: cidr
+
+- name: "Multiple: Allocate with some used CIDRs"
+  ansible.utils.cidr_allocate:
+    master_cidr: "{{ multi_master_cidr }}"
+    prefix_length: "{{ multi_prefix_length }}"
+    count: 2
+    used_cidrs:
+      - "10.0.0.0/24"
+  register: multi_used_result
+
+- name: "Multiple: Verify allocations avoid used CIDRs"
+  ansible.builtin.assert:
+    that:
+      - multi_used_result is success
+      - multi_used_result.count == 2
+      - "'10.0.0.0/24' not in multi_used_result.allocated_cidrs"

--- a/tests/integration/targets/utils_cidr_allocate/tasks/simple.yml
+++ b/tests/integration/targets/utils_cidr_allocate/tasks/simple.yml
@@ -1,0 +1,43 @@
+---
+- name: "Simple: Allocate a single /24 from empty range"
+  ansible.utils.cidr_allocate:
+    master_cidr: "{{ simple_master_cidr }}"
+    prefix_length: "{{ simple_prefix_length }}"
+    used_cidrs: []
+  register: simple_result
+
+- name: "Simple: Verify single allocation"
+  ansible.builtin.assert:
+    that:
+      - simple_result is success
+      - simple_result.changed == false
+      - simple_result.count == 1
+      - simple_result.allocated_cidrs | length == 1
+      - simple_result.allocated_cidrs[0] == simple_expected_cidr
+
+- name: "Simple: Allocate with exclusions"
+  ansible.utils.cidr_allocate:
+    master_cidr: "{{ exclusion_master_cidr }}"
+    prefix_length: "{{ exclusion_prefix_length }}"
+    used_cidrs: "{{ exclusion_used_cidrs }}"
+  register: exclusion_result
+
+- name: "Simple: Verify exclusion allocation does not overlap used CIDRs"
+  ansible.builtin.assert:
+    that:
+      - exclusion_result is success
+      - exclusion_result.allocated_cidrs | length == 1
+      - exclusion_result.allocated_cidrs[0] not in exclusion_used_cidrs
+
+- name: "Simple: Verify best-fit selects smallest gap"
+  ansible.utils.cidr_allocate:
+    master_cidr: "{{ bestfit_master_cidr }}"
+    prefix_length: "{{ bestfit_prefix_length }}"
+    used_cidrs: "{{ bestfit_used_cidrs }}"
+  register: bestfit_result
+
+- name: "Simple: Assert best-fit picked the smallest gap"
+  ansible.builtin.assert:
+    that:
+      - bestfit_result is success
+      - bestfit_result.allocated_cidrs[0] == bestfit_expected_cidr

--- a/tests/integration/targets/utils_cidr_allocate/vars/main.yml
+++ b/tests/integration/targets/utils_cidr_allocate/vars/main.yml
@@ -1,0 +1,27 @@
+---
+# Test data for cidr_allocate integration tests
+
+# Simple allocation tests
+simple_master_cidr: "10.0.0.0/8"
+simple_prefix_length: 24
+simple_expected_cidr: "10.0.0.0/24"
+
+# Allocation with exclusions
+exclusion_master_cidr: "10.0.0.0/24"
+exclusion_used_cidrs:
+  - "10.0.0.0/26"
+  - "10.0.0.64/26"
+exclusion_prefix_length: 26
+
+# Best-fit test
+bestfit_master_cidr: "10.0.0.0/24"
+bestfit_used_cidrs:
+  - "10.0.0.16/28"
+  - "10.0.0.64/26"
+bestfit_prefix_length: 28
+bestfit_expected_cidr: "10.0.0.0/28"
+
+# Multiple allocation tests
+multi_master_cidr: "10.0.0.0/22"
+multi_prefix_length: 24
+multi_count: 3

--- a/tests/unit/plugins/modules/test_cidr_allocate.py
+++ b/tests/unit/plugins/modules/test_cidr_allocate.py
@@ -1,0 +1,499 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit test file for cidr_allocate module
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import ipaddress
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.ansible.utils.plugins.modules.cidr_allocate import (
+    CIDRAllocator,
+    run_module,
+)
+
+
+# ---------------------------------------------------------------------------
+# CIDRAllocator – Initialization & Validation
+# ---------------------------------------------------------------------------
+
+
+class TestCIDRAllocatorInit(TestCase):
+    """Test CIDRAllocator initialization and input validation."""
+
+    def test_valid_initialization(self):
+        allocator = CIDRAllocator("10.0.0.0/8", [], 24)
+        self.assertEqual(allocator.master_network, ipaddress.ip_network("10.0.0.0/8"))
+        self.assertEqual(allocator.prefix_length, 24)
+        self.assertEqual(allocator.used_networks, [])
+
+    def test_valid_initialization_with_used_cidrs(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/8", ["10.0.0.0/24", "10.0.1.0/24"], 24
+        )
+        self.assertEqual(len(allocator.used_networks), 2)
+
+    def test_invalid_master_cidr_string(self):
+        with self.assertRaises(ValueError) as ctx:
+            CIDRAllocator("not-a-cidr", [], 24)
+        self.assertIn("Invalid master CIDR", str(ctx.exception))
+
+    def test_prefix_length_smaller_than_master(self):
+        with self.assertRaises(ValueError) as ctx:
+            CIDRAllocator("10.0.0.0/16", [], 8)
+        self.assertIn("smaller than master CIDR prefix length", str(ctx.exception))
+
+    def test_prefix_length_greater_than_32(self):
+        with self.assertRaises(ValueError) as ctx:
+            CIDRAllocator("10.0.0.0/8", [], 33)
+        self.assertIn("must be <= 32", str(ctx.exception))
+
+    def test_invalid_used_cidr_entry(self):
+        with self.assertRaises(ValueError) as ctx:
+            CIDRAllocator("10.0.0.0/8", ["bad-cidr"], 24)
+        self.assertIn("Invalid CIDR in used_cidrs", str(ctx.exception))
+
+    def test_used_cidrs_outside_master_are_filtered(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/8", ["192.168.1.0/24", "10.0.0.0/24"], 24
+        )
+        self.assertEqual(len(allocator.used_networks), 1)
+        self.assertEqual(
+            allocator.used_networks[0], ipaddress.ip_network("10.0.0.0/24")
+        )
+
+    def test_used_cidrs_sorted_by_network_address(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/8", ["10.0.2.0/24", "10.0.0.0/24", "10.0.1.0/24"], 24
+        )
+        addresses = [net.network_address for net in allocator.used_networks]
+        self.assertEqual(addresses, sorted(addresses))
+
+
+# ---------------------------------------------------------------------------
+# CIDRAllocator – Internal methods
+# ---------------------------------------------------------------------------
+
+
+class TestMergeOverlappingRanges(TestCase):
+    """Test the _merge_overlapping_ranges internal method."""
+
+    def test_empty_used_networks(self):
+        allocator = CIDRAllocator("10.0.0.0/8", [], 24)
+        self.assertEqual(allocator._merge_overlapping_ranges(), [])
+
+    def test_single_used_network(self):
+        allocator = CIDRAllocator("10.0.0.0/8", ["10.0.0.0/24"], 24)
+        merged = allocator._merge_overlapping_ranges()
+        self.assertEqual(len(merged), 1)
+        start = int(ipaddress.IPv4Address("10.0.0.0"))
+        end = int(ipaddress.IPv4Address("10.0.0.255"))
+        self.assertEqual(merged[0], (start, end))
+
+    def test_non_overlapping_ranges(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/8", ["10.0.0.0/24", "10.0.2.0/24"], 24
+        )
+        merged = allocator._merge_overlapping_ranges()
+        self.assertEqual(len(merged), 2)
+
+    def test_overlapping_ranges_merged(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/8", ["10.0.0.0/24", "10.0.0.128/25"], 24
+        )
+        merged = allocator._merge_overlapping_ranges()
+        self.assertEqual(len(merged), 1)
+
+    def test_adjacent_ranges_merged(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/8", ["10.0.0.0/24", "10.0.1.0/24"], 24
+        )
+        merged = allocator._merge_overlapping_ranges()
+        self.assertEqual(len(merged), 1)
+        start = int(ipaddress.IPv4Address("10.0.0.0"))
+        end = int(ipaddress.IPv4Address("10.0.1.255"))
+        self.assertEqual(merged[0], (start, end))
+
+
+class TestFindAvailableGaps(TestCase):
+    """Test the _find_available_gaps internal method."""
+
+    def test_no_used_cidrs_whole_master_is_gap(self):
+        allocator = CIDRAllocator("10.0.0.0/24", [], 28)
+        gaps = allocator._find_available_gaps()
+        self.assertEqual(len(gaps), 1)
+        start = int(ipaddress.IPv4Address("10.0.0.0"))
+        end = int(ipaddress.IPv4Address("10.0.0.255"))
+        self.assertEqual(gaps[0], (start, end))
+
+    def test_gap_before_first_used(self):
+        allocator = CIDRAllocator("10.0.0.0/24", ["10.0.0.128/25"], 28)
+        gaps = allocator._find_available_gaps()
+        # Should have gap from 10.0.0.0 to 10.0.0.127
+        self.assertTrue(
+            any(
+                s == int(ipaddress.IPv4Address("10.0.0.0"))
+                and e == int(ipaddress.IPv4Address("10.0.0.127"))
+                for s, e in gaps
+            )
+        )
+
+    def test_gap_after_last_used(self):
+        allocator = CIDRAllocator("10.0.0.0/24", ["10.0.0.0/25"], 28)
+        gaps = allocator._find_available_gaps()
+        self.assertTrue(
+            any(
+                s == int(ipaddress.IPv4Address("10.0.0.128"))
+                and e == int(ipaddress.IPv4Address("10.0.0.255"))
+                for s, e in gaps
+            )
+        )
+
+    def test_gap_between_used_ranges(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/24", ["10.0.0.0/26", "10.0.0.128/26"], 28
+        )
+        gaps = allocator._find_available_gaps()
+        # Gap should be 10.0.0.64 - 10.0.0.127
+        self.assertTrue(
+            any(
+                s == int(ipaddress.IPv4Address("10.0.0.64"))
+                and e == int(ipaddress.IPv4Address("10.0.0.127"))
+                for s, e in gaps
+            )
+        )
+
+    def test_fully_used_no_gaps(self):
+        allocator = CIDRAllocator("10.0.0.0/24", ["10.0.0.0/24"], 28)
+        gaps = allocator._find_available_gaps()
+        self.assertEqual(gaps, [])
+
+
+class TestFindAlignedCidrInGap(TestCase):
+    """Test the _find_aligned_cidr_in_gap internal method."""
+
+    def test_aligned_start(self):
+        allocator = CIDRAllocator("10.0.0.0/8", [], 24)
+        gap_start = int(ipaddress.IPv4Address("10.0.0.0"))
+        gap_end = int(ipaddress.IPv4Address("10.0.0.255"))
+        result = allocator._find_aligned_cidr_in_gap(gap_start, gap_end)
+        self.assertIsNotNone(result)
+        self.assertEqual(str(result), "10.0.0.0/24")
+
+    def test_unaligned_start_finds_next_aligned(self):
+        allocator = CIDRAllocator("10.0.0.0/8", [], 24)
+        # Gap starts at 10.0.0.1 (not aligned for /24)
+        gap_start = int(ipaddress.IPv4Address("10.0.0.1"))
+        gap_end = int(ipaddress.IPv4Address("10.0.1.255"))
+        result = allocator._find_aligned_cidr_in_gap(gap_start, gap_end)
+        self.assertIsNotNone(result)
+        self.assertEqual(str(result), "10.0.1.0/24")
+
+    def test_gap_too_small_returns_none(self):
+        allocator = CIDRAllocator("10.0.0.0/8", [], 24)
+        # Gap only has 100 addresses – not enough for /24 (256)
+        gap_start = int(ipaddress.IPv4Address("10.0.0.1"))
+        gap_end = int(ipaddress.IPv4Address("10.0.0.100"))
+        result = allocator._find_aligned_cidr_in_gap(gap_start, gap_end)
+        self.assertIsNone(result)
+
+    def test_prefix_32_single_host(self):
+        allocator = CIDRAllocator("10.0.0.0/24", [], 32)
+        gap_start = int(ipaddress.IPv4Address("10.0.0.5"))
+        gap_end = int(ipaddress.IPv4Address("10.0.0.5"))
+        result = allocator._find_aligned_cidr_in_gap(gap_start, gap_end)
+        self.assertIsNotNone(result)
+        self.assertEqual(str(result), "10.0.0.5/32")
+
+
+# ---------------------------------------------------------------------------
+# CIDRAllocator – allocate_single
+# ---------------------------------------------------------------------------
+
+
+class TestAllocateSingle(TestCase):
+    """Test the allocate_single method."""
+
+    def test_allocate_from_empty_master(self):
+        allocator = CIDRAllocator("10.0.0.0/8", [], 24)
+        result = allocator.allocate_single()
+        self.assertEqual(result, "10.0.0.0/24")
+
+    def test_allocate_avoiding_used_cidrs(self):
+        allocator = CIDRAllocator("10.0.0.0/24", ["10.0.0.0/26"], 26)
+        result = allocator.allocate_single()
+        # Should allocate in the remaining space after 10.0.0.0/26
+        allocated = ipaddress.ip_network(result)
+        used = ipaddress.ip_network("10.0.0.0/26")
+        self.assertFalse(allocated.overlaps(used))
+        self.assertEqual(allocated.prefixlen, 26)
+
+    def test_best_fit_prefers_smallest_gap(self):
+        # Master: 10.0.0.0/24 (256 addresses)
+        # Used: 10.0.0.16/28 (16 addresses at offset 16-31) and 10.0.0.64/26 (64 addresses at 64-127)
+        # Gaps: [0-15] (16 addr), [32-63] (32 addr), [128-255] (128 addr)
+        # Requesting /28 (16 addresses): best-fit should pick the 16-addr gap [0-15]
+        allocator = CIDRAllocator(
+            "10.0.0.0/24", ["10.0.0.16/28", "10.0.0.64/26"], 28
+        )
+        result = allocator.allocate_single()
+        self.assertEqual(result, "10.0.0.0/28")
+
+    def test_full_address_space_raises(self):
+        allocator = CIDRAllocator("10.0.0.0/24", ["10.0.0.0/24"], 28)
+        with self.assertRaises(ValueError) as ctx:
+            allocator.allocate_single()
+        self.assertIn("No available address space", str(ctx.exception))
+
+    def test_no_aligned_block_fits_raises(self):
+        # Master: 10.0.0.0/28 (16 addresses: 10.0.0.0-10.0.0.15)
+        # Used: 10.0.0.0/32 (takes 10.0.0.0)
+        # Gap: 10.0.0.1-10.0.0.15 (15 addresses, unaligned for /28)
+        # Requesting /28 needs 16 aligned addresses; the gap starts at .1, not aligned
+        allocator = CIDRAllocator("10.0.0.0/28", ["10.0.0.0/32"], 28)
+        with self.assertRaises(ValueError) as ctx:
+            allocator.allocate_single()
+        self.assertIn("No suitable gaps found", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# CIDRAllocator – allocate_multiple
+# ---------------------------------------------------------------------------
+
+
+class TestAllocateMultiple(TestCase):
+    """Test the allocate_multiple method."""
+
+    def test_allocate_count_3(self):
+        allocator = CIDRAllocator("10.0.0.0/22", [], 24)
+        results = allocator.allocate_multiple(3)
+        self.assertEqual(len(results), 3)
+        # Verify no overlaps
+        networks = [ipaddress.ip_network(r) for r in results]
+        for i in range(len(networks)):
+            for j in range(i + 1, len(networks)):
+                self.assertFalse(
+                    networks[i].overlaps(networks[j]),
+                    f"{networks[i]} overlaps {networks[j]}",
+                )
+
+    def test_allocate_multiple_all_within_master(self):
+        master = "10.0.0.0/22"
+        allocator = CIDRAllocator(master, [], 24)
+        results = allocator.allocate_multiple(4)
+        master_net = ipaddress.ip_network(master)
+        for cidr in results:
+            net = ipaddress.ip_network(cidr)
+            self.assertTrue(
+                net.subnet_of(master_net),
+                f"{net} is not within {master_net}",
+            )
+
+    def test_partial_failure_raises(self):
+        # /24 has room for exactly 1 /24
+        allocator = CIDRAllocator("10.0.0.0/24", [], 24)
+        with self.assertRaises(ValueError) as ctx:
+            allocator.allocate_multiple(2)
+        self.assertIn("Could only allocate 1 of 2", str(ctx.exception))
+
+    def test_each_allocation_avoids_previous(self):
+        allocator = CIDRAllocator("10.0.0.0/22", [], 24)
+        results = allocator.allocate_multiple(3)
+        # All should be distinct
+        self.assertEqual(len(set(results)), 3)
+
+
+# ---------------------------------------------------------------------------
+# CIDRAllocator – Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases(TestCase):
+    """Test edge-case scenarios."""
+
+    def test_prefix_32_single_host_allocation(self):
+        allocator = CIDRAllocator("10.0.0.0/30", [], 32)
+        result = allocator.allocate_single()
+        net = ipaddress.ip_network(result)
+        self.assertEqual(net.prefixlen, 32)
+
+    def test_master_equals_prefix_length(self):
+        allocator = CIDRAllocator("10.0.0.0/24", [], 24)
+        result = allocator.allocate_single()
+        self.assertEqual(result, "10.0.0.0/24")
+
+    def test_master_equals_prefix_length_only_one_block(self):
+        allocator = CIDRAllocator("10.0.0.0/24", [], 24)
+        with self.assertRaises(ValueError):
+            allocator.allocate_multiple(2)
+
+    def test_used_cidrs_outside_master_ignored(self):
+        allocator = CIDRAllocator(
+            "10.0.0.0/24", ["192.168.0.0/16", "172.16.0.0/12"], 28
+        )
+        # No used_networks should be stored since none overlap
+        self.assertEqual(len(allocator.used_networks), 0)
+        result = allocator.allocate_single()
+        self.assertEqual(result, "10.0.0.0/28")
+
+    def test_overlapping_used_cidrs_merged(self):
+        # 10.0.0.0/25 and 10.0.0.0/26 overlap (the /26 is inside the /25)
+        allocator = CIDRAllocator(
+            "10.0.0.0/24", ["10.0.0.0/25", "10.0.0.0/26"], 25
+        )
+        merged = allocator._merge_overlapping_ranges()
+        self.assertEqual(len(merged), 1)
+        # The merged range should cover the entire /25
+        self.assertEqual(
+            merged[0][0], int(ipaddress.IPv4Address("10.0.0.0"))
+        )
+        self.assertEqual(
+            merged[0][1], int(ipaddress.IPv4Address("10.0.0.127"))
+        )
+
+    def test_allocate_multiple_prefix_32(self):
+        allocator = CIDRAllocator("10.0.0.0/30", [], 32)
+        results = allocator.allocate_multiple(4)
+        self.assertEqual(len(results), 4)
+        self.assertEqual(len(set(results)), 4)
+
+
+# ---------------------------------------------------------------------------
+# run_module – integration with AnsibleModule
+# ---------------------------------------------------------------------------
+
+
+class TestRunModule(TestCase):
+    """Test the run_module function via AnsibleModule mocking."""
+
+    @patch(
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+    )
+    def test_single_allocation_success(self, mock_module_cls):
+        mock_module = MagicMock()
+        mock_module_cls.return_value = mock_module
+        mock_module.params = {
+            "master_cidr": "10.0.0.0/8",
+            "used_cidrs": [],
+            "prefix_length": 24,
+            "count": 1,
+        }
+        mock_module.check_mode = False
+
+        run_module()
+
+        mock_module.exit_json.assert_called_once()
+        call_kwargs = mock_module.exit_json.call_args[1]
+        self.assertEqual(call_kwargs["changed"], False)
+        self.assertEqual(call_kwargs["allocated_cidrs"], ["10.0.0.0/24"])
+        self.assertEqual(call_kwargs["count"], 1)
+
+    @patch(
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+    )
+    def test_multiple_allocation_success(self, mock_module_cls):
+        mock_module = MagicMock()
+        mock_module_cls.return_value = mock_module
+        mock_module.params = {
+            "master_cidr": "10.0.0.0/22",
+            "used_cidrs": [],
+            "prefix_length": 24,
+            "count": 3,
+        }
+        mock_module.check_mode = False
+
+        run_module()
+
+        mock_module.exit_json.assert_called_once()
+        call_kwargs = mock_module.exit_json.call_args[1]
+        self.assertEqual(call_kwargs["count"], 3)
+        self.assertEqual(len(call_kwargs["allocated_cidrs"]), 3)
+
+    @patch(
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+    )
+    def test_invalid_master_cidr_fails(self, mock_module_cls):
+        mock_module = MagicMock()
+        mock_module_cls.return_value = mock_module
+        mock_module.params = {
+            "master_cidr": "not-valid",
+            "used_cidrs": [],
+            "prefix_length": 24,
+            "count": 1,
+        }
+        mock_module.check_mode = False
+
+        run_module()
+
+        mock_module.fail_json.assert_called_once()
+        fail_msg = mock_module.fail_json.call_args[1]["msg"]
+        self.assertIn("Invalid master CIDR", fail_msg)
+
+    @patch(
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+    )
+    def test_count_less_than_1_fails(self, mock_module_cls):
+        mock_module = MagicMock()
+        mock_module_cls.return_value = mock_module
+        mock_module.params = {
+            "master_cidr": "10.0.0.0/8",
+            "used_cidrs": [],
+            "prefix_length": 24,
+            "count": 0,
+        }
+        mock_module.check_mode = False
+
+        run_module()
+
+        mock_module.fail_json.assert_called_once()
+        fail_msg = mock_module.fail_json.call_args[1]["msg"]
+        self.assertIn("count must be at least 1", fail_msg)
+
+    @patch(
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+    )
+    def test_exhausted_space_fails(self, mock_module_cls):
+        mock_module = MagicMock()
+        mock_module_cls.return_value = mock_module
+        mock_module.params = {
+            "master_cidr": "10.0.0.0/24",
+            "used_cidrs": ["10.0.0.0/24"],
+            "prefix_length": 28,
+            "count": 1,
+        }
+        mock_module.check_mode = False
+
+        run_module()
+
+        mock_module.fail_json.assert_called_once()
+
+    @patch(
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+    )
+    def test_allocation_with_used_cidrs(self, mock_module_cls):
+        mock_module = MagicMock()
+        mock_module_cls.return_value = mock_module
+        mock_module.params = {
+            "master_cidr": "10.0.0.0/24",
+            "used_cidrs": ["10.0.0.0/26"],
+            "prefix_length": 26,
+            "count": 1,
+        }
+        mock_module.check_mode = False
+
+        run_module()
+
+        mock_module.exit_json.assert_called_once()
+        call_kwargs = mock_module.exit_json.call_args[1]
+        allocated = ipaddress.ip_network(call_kwargs["allocated_cidrs"][0])
+        used = ipaddress.ip_network("10.0.0.0/26")
+        self.assertFalse(allocated.overlaps(used))

--- a/tests/unit/plugins/modules/test_cidr_allocate.py
+++ b/tests/unit/plugins/modules/test_cidr_allocate.py
@@ -9,6 +9,7 @@ Unit test file for cidr_allocate module
 
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 import ipaddress
@@ -38,7 +39,9 @@ class TestCIDRAllocatorInit(TestCase):
 
     def test_valid_initialization_with_used_cidrs(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/8", ["10.0.0.0/24", "10.0.1.0/24"], 24
+            "10.0.0.0/8",
+            ["10.0.0.0/24", "10.0.1.0/24"],
+            24,
         )
         self.assertEqual(len(allocator.used_networks), 2)
 
@@ -64,16 +67,21 @@ class TestCIDRAllocatorInit(TestCase):
 
     def test_used_cidrs_outside_master_are_filtered(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/8", ["192.168.1.0/24", "10.0.0.0/24"], 24
+            "10.0.0.0/8",
+            ["192.168.1.0/24", "10.0.0.0/24"],
+            24,
         )
         self.assertEqual(len(allocator.used_networks), 1)
         self.assertEqual(
-            allocator.used_networks[0], ipaddress.ip_network("10.0.0.0/24")
+            allocator.used_networks[0],
+            ipaddress.ip_network("10.0.0.0/24"),
         )
 
     def test_used_cidrs_sorted_by_network_address(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/8", ["10.0.2.0/24", "10.0.0.0/24", "10.0.1.0/24"], 24
+            "10.0.0.0/8",
+            ["10.0.2.0/24", "10.0.0.0/24", "10.0.1.0/24"],
+            24,
         )
         addresses = [net.network_address for net in allocator.used_networks]
         self.assertEqual(addresses, sorted(addresses))
@@ -101,21 +109,27 @@ class TestMergeOverlappingRanges(TestCase):
 
     def test_non_overlapping_ranges(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/8", ["10.0.0.0/24", "10.0.2.0/24"], 24
+            "10.0.0.0/8",
+            ["10.0.0.0/24", "10.0.2.0/24"],
+            24,
         )
         merged = allocator._merge_overlapping_ranges()
         self.assertEqual(len(merged), 2)
 
     def test_overlapping_ranges_merged(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/8", ["10.0.0.0/24", "10.0.0.128/25"], 24
+            "10.0.0.0/8",
+            ["10.0.0.0/24", "10.0.0.128/25"],
+            24,
         )
         merged = allocator._merge_overlapping_ranges()
         self.assertEqual(len(merged), 1)
 
     def test_adjacent_ranges_merged(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/8", ["10.0.0.0/24", "10.0.1.0/24"], 24
+            "10.0.0.0/8",
+            ["10.0.0.0/24", "10.0.1.0/24"],
+            24,
         )
         merged = allocator._merge_overlapping_ranges()
         self.assertEqual(len(merged), 1)
@@ -144,7 +158,7 @@ class TestFindAvailableGaps(TestCase):
                 s == int(ipaddress.IPv4Address("10.0.0.0"))
                 and e == int(ipaddress.IPv4Address("10.0.0.127"))
                 for s, e in gaps
-            )
+            ),
         )
 
     def test_gap_after_last_used(self):
@@ -155,12 +169,14 @@ class TestFindAvailableGaps(TestCase):
                 s == int(ipaddress.IPv4Address("10.0.0.128"))
                 and e == int(ipaddress.IPv4Address("10.0.0.255"))
                 for s, e in gaps
-            )
+            ),
         )
 
     def test_gap_between_used_ranges(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/24", ["10.0.0.0/26", "10.0.0.128/26"], 28
+            "10.0.0.0/24",
+            ["10.0.0.0/26", "10.0.0.128/26"],
+            28,
         )
         gaps = allocator._find_available_gaps()
         # Gap should be 10.0.0.64 - 10.0.0.127
@@ -169,7 +185,7 @@ class TestFindAvailableGaps(TestCase):
                 s == int(ipaddress.IPv4Address("10.0.0.64"))
                 and e == int(ipaddress.IPv4Address("10.0.0.127"))
                 for s, e in gaps
-            )
+            ),
         )
 
     def test_fully_used_no_gaps(self):
@@ -243,7 +259,9 @@ class TestAllocateSingle(TestCase):
         # Gaps: [0-15] (16 addr), [32-63] (32 addr), [128-255] (128 addr)
         # Requesting /28 (16 addresses): best-fit should pick the 16-addr gap [0-15]
         allocator = CIDRAllocator(
-            "10.0.0.0/24", ["10.0.0.16/28", "10.0.0.64/26"], 28
+            "10.0.0.0/24",
+            ["10.0.0.16/28", "10.0.0.64/26"],
+            28,
         )
         result = allocator.allocate_single()
         self.assertEqual(result, "10.0.0.0/28")
@@ -338,7 +356,9 @@ class TestEdgeCases(TestCase):
 
     def test_used_cidrs_outside_master_ignored(self):
         allocator = CIDRAllocator(
-            "10.0.0.0/24", ["192.168.0.0/16", "172.16.0.0/12"], 28
+            "10.0.0.0/24",
+            ["192.168.0.0/16", "172.16.0.0/12"],
+            28,
         )
         # No used_networks should be stored since none overlap
         self.assertEqual(len(allocator.used_networks), 0)
@@ -348,16 +368,20 @@ class TestEdgeCases(TestCase):
     def test_overlapping_used_cidrs_merged(self):
         # 10.0.0.0/25 and 10.0.0.0/26 overlap (the /26 is inside the /25)
         allocator = CIDRAllocator(
-            "10.0.0.0/24", ["10.0.0.0/25", "10.0.0.0/26"], 25
+            "10.0.0.0/24",
+            ["10.0.0.0/25", "10.0.0.0/26"],
+            25,
         )
         merged = allocator._merge_overlapping_ranges()
         self.assertEqual(len(merged), 1)
         # The merged range should cover the entire /25
         self.assertEqual(
-            merged[0][0], int(ipaddress.IPv4Address("10.0.0.0"))
+            merged[0][0],
+            int(ipaddress.IPv4Address("10.0.0.0")),
         )
         self.assertEqual(
-            merged[0][1], int(ipaddress.IPv4Address("10.0.0.127"))
+            merged[0][1],
+            int(ipaddress.IPv4Address("10.0.0.127")),
         )
 
     def test_allocate_multiple_prefix_32(self):
@@ -376,7 +400,7 @@ class TestRunModule(TestCase):
     """Test the run_module function via AnsibleModule mocking."""
 
     @patch(
-        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule",
     )
     def test_single_allocation_success(self, mock_module_cls):
         mock_module = MagicMock()
@@ -398,7 +422,7 @@ class TestRunModule(TestCase):
         self.assertEqual(call_kwargs["count"], 1)
 
     @patch(
-        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule",
     )
     def test_multiple_allocation_success(self, mock_module_cls):
         mock_module = MagicMock()
@@ -419,7 +443,7 @@ class TestRunModule(TestCase):
         self.assertEqual(len(call_kwargs["allocated_cidrs"]), 3)
 
     @patch(
-        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule",
     )
     def test_invalid_master_cidr_fails(self, mock_module_cls):
         mock_module = MagicMock()
@@ -439,7 +463,7 @@ class TestRunModule(TestCase):
         self.assertIn("Invalid master CIDR", fail_msg)
 
     @patch(
-        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule",
     )
     def test_count_less_than_1_fails(self, mock_module_cls):
         mock_module = MagicMock()
@@ -459,7 +483,7 @@ class TestRunModule(TestCase):
         self.assertIn("count must be at least 1", fail_msg)
 
     @patch(
-        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule",
     )
     def test_exhausted_space_fails(self, mock_module_cls):
         mock_module = MagicMock()
@@ -477,7 +501,7 @@ class TestRunModule(TestCase):
         mock_module.fail_json.assert_called_once()
 
     @patch(
-        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule"
+        "ansible_collections.ansible.utils.plugins.modules.cidr_allocate.AnsibleModule",
     )
     def test_allocation_with_used_cidrs(self, mock_module_cls):
         mock_module = MagicMock()


### PR DESCRIPTION
## Summary
- Adds a new `cidr_allocate` module that finds and allocates available CIDR blocks of a specified size within a master CIDR range
- Uses a best-fit algorithm to minimize address space fragmentation and supports allocating multiple non-overlapping blocks in a single call
- Includes unit tests and integration tests

## Test plan
- [x] `ansible-test sanity` passes on all new files (32 tests)
- [ ] `ansible-test units` for `test_cidr_allocate.py`
- [ ] `ansible-test integration` for `utils_cidr_allocate` target