### PR TITLE
fix in_network test in Python 3.14

### DIFF
--- a/plugins/plugin_utils/base/ipaddress_utils.py
+++ b/plugins/plugin_utils/base/ipaddress_utils.py
@@ -60,9 +60,18 @@ def _need_ipaddress(func):
     return wrapper
 
 
+def _get_network_version(network):
+    """
+    Python 3.14 changes the _version attribute to version, so we have to try both.
+    """
+    if hasattr(network, "_version"):
+        return network._version
+    return network.version
+
+
 def _is_subnet_of(network_a, network_b):
     try:
-        if network_a._version != network_b._version:
+        if _get_network_version(network_a) != _get_network_version(network_b):
             return False
         return (
             network_b.network_address <= network_a.network_address


### PR DESCRIPTION
##### SUMMARY
Fixes #425 

The property `_version` of `ipaddress.IPv4Network` was made public in 3.14, which causes the test for equality of `_version`s to fail, which in turn causes the except block to return false. This is fixed by checking both private and public names.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.utils.in_network
