### PR TITLE
Make ipwrap docs match behaviour

### DIFF
--- a/changelogs/fragments/remove-ipaddr-warning-message-update-docs.yml
+++ b/changelogs/fragments/remove-ipaddr-warning-message-update-docs.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - remove warning message about potential instability of ipaddr (it has been stable for years)
+trivial:
+  - update ipwrap docs

--- a/docs/ansible.utils.ipwrap_filter.rst
+++ b/docs/ansible.utils.ipwrap_filter.rst
@@ -84,7 +84,7 @@ Examples
 .. code-block:: yaml
 
     #### examples
-    # Ipwrap filter plugin o Wrap IPv6 addresses in [ ] brackets.
+    # Ipwrap filter plugin to wrap IPv6 addresses in [ ] brackets.
     - name: Set value as input list
       ansible.builtin.set_fact:
         value:

--- a/docs/ansible.utils.ipwrap_filter.rst
+++ b/docs/ansible.utils.ipwrap_filter.rst
@@ -101,14 +101,14 @@ Examples
         msg: "{{ value }}"
 
     - name: Show ipwrap result
-        ansible.builtin.debug:
+      ansible.builtin.debug:
         msg: "{{ value | ansible.utils.ipwrap }}"
 
         # ipwrap() did not filter out non-IP address values, which is usually what you want, e.g. when
         # you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
         # you can chain both filters together.
     - name: Show combined result of ipaddr and ipwrap
-        ansible.builtin.debug:
+      ansible.builtin.debug:
         msg: "{{ value | ansible.utils.ipaddr | ansible.utils.ipwrap  }}"
 
     # PLAY [Ipwrap filter plugin to wrap IPv6 addresses in [ ] brackets.] *************************************************

--- a/docs/ansible.utils.ipwrap_filter.rst
+++ b/docs/ansible.utils.ipwrap_filter.rst
@@ -97,7 +97,7 @@ Examples
           - 42540766412265424405338506004571095040/64
           - true
     - name: Show input
-        ansible.builtin.debug:
+      ansible.builtin.debug:
         msg: "{{ value }}"
 
     - name: Show ipwrap result

--- a/docs/ansible.utils.ipwrap_filter.rst
+++ b/docs/ansible.utils.ipwrap_filter.rst
@@ -96,33 +96,40 @@ Examples
           - fe80::100/10
           - 42540766412265424405338506004571095040/64
           - true
-    - debug:
-        msg: "{{ value|ansible.utils.ipwrap }}"
+    - name: Show input
+        ansible.builtin.debug:
+        msg: "{{ value }}"
 
-    - name: |
-            ipwrap() did not filter out non-IP address values, which is usually what you want when for example
-            you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
-            you can chain both filters together.
-      debug:
-        msg: "{{ value|ansible.utils.ipaddr|ansible.utils.ipwrap  }}"
+    - name: Show ipwrap result
+        ansible.builtin.debug:
+        msg: "{{ value | ansible.utils.ipwrap }}"
 
-    # PLAY [Ipwrap filter plugin o Wrap IPv6 addresses in [ ] brackets.] ***************************************************
-    # TASK [Set value as input list] ***************************************************************************************
-    # ok: [localhost] => {"ansible_facts": {"value": ["192.24.2.1", "host.fqdn", "::1", "", "192.168.32.0/24",
-    # "fe80::100/10", "42540766412265424405338506004571095040/64", true]}, "changed": false}
-    #
-    # TASK [debug] ********************************************************************************************************
+        # ipwrap() did not filter out non-IP address values, which is usually what you want, e.g. when
+        # you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
+        # you can chain both filters together.
+    - name: Show combined result of ipaddr and ipwrap
+        ansible.builtin.debug:
+        msg: "{{ value | ansible.utils.ipaddr | ansible.utils.ipwrap  }}"
+
+    # PLAY [Ipwrap filter plugin to wrap IPv6 addresses in [ ] brackets.] *************************************************
+    # TASK [Set value as input list] **************************************************************************************
+    # ok: [localhost]
+
+    # TASK [Show input] ***************************************************************************************************
     # ok: [localhost] => {
     #     "msg": [
     #         "192.24.2.1",
+    #         "host.fqdn",
     #         "::1",
+    #         "",
     #         "192.168.32.0/24",
     #         "fe80::100/10",
-    #         "2001:db8:32c:faad::/64"
+    #         "42540766412265424405338506004571095040/64",
+    #         true
     #     ]
     # }
-    #
-    # TASK [debug] ************************************************************************************************
+
+    # TASK [Show ipwrap result] *******************************************************************************************
     # ok: [localhost] => {
     #     "msg": [
     #         "192.24.2.1",
@@ -132,13 +139,11 @@ Examples
     #         "192.168.32.0/24",
     #         "[fe80::100]/10",
     #         "[2001:db8:32c:faad::]/64",
-    #         "True"
+    #         true
     #     ]
     # }
-    #
-    # TASK [ipwrap() did not filter out non-IP address values, which is usually what you want when for example
-    # you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
-    # you can chain both filters together.] ***
+
+    # TASK [Show combined result of ipaddr and ipwrap] ********************************************************************
     # ok: [localhost] => {
     #     "msg": [
     #         "192.24.2.1",

--- a/plugins/filter/ipwrap.py
+++ b/plugins/filter/ipwrap.py
@@ -88,14 +88,14 @@ EXAMPLES = r"""
     msg: "{{ value }}"
 
 - name: Show ipwrap result
-    ansible.builtin.debug:
+  ansible.builtin.debug:
     msg: "{{ value | ansible.utils.ipwrap }}"
 
     # ipwrap() did not filter out non-IP address values, which is usually what you want, e.g. when
     # you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
     # you can chain both filters together.
 - name: Show combined result of ipaddr and ipwrap
-    ansible.builtin.debug:
+  ansible.builtin.debug:
     msg: "{{ value | ansible.utils.ipaddr | ansible.utils.ipwrap  }}"
 
 # PLAY [Ipwrap filter plugin to wrap IPv6 addresses in [ ] brackets.] *************************************************

--- a/plugins/filter/ipwrap.py
+++ b/plugins/filter/ipwrap.py
@@ -71,7 +71,7 @@ DOCUMENTATION = """
 
 EXAMPLES = r"""
 #### examples
-# Ipwrap filter plugin o Wrap IPv6 addresses in [ ] brackets.
+# Ipwrap filter plugin to wrap IPv6 addresses in [ ] brackets.
 - name: Set value as input list
   ansible.builtin.set_fact:
     value:

--- a/plugins/filter/ipwrap.py
+++ b/plugins/filter/ipwrap.py
@@ -83,33 +83,40 @@ EXAMPLES = r"""
       - fe80::100/10
       - 42540766412265424405338506004571095040/64
       - true
-- debug:
-    msg: "{{ value|ansible.utils.ipwrap }}"
+- name: Show input
+    ansible.builtin.debug:
+    msg: "{{ value }}"
 
-- name: |
-        ipwrap() did not filter out non-IP address values, which is usually what you want when for example
-        you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
-        you can chain both filters together.
-  debug:
-    msg: "{{ value|ansible.utils.ipaddr|ansible.utils.ipwrap  }}"
+- name: Show ipwrap result
+    ansible.builtin.debug:
+    msg: "{{ value | ansible.utils.ipwrap }}"
 
-# PLAY [Ipwrap filter plugin o Wrap IPv6 addresses in [ ] brackets.] ***************************************************
-# TASK [Set value as input list] ***************************************************************************************
-# ok: [localhost] => {"ansible_facts": {"value": ["192.24.2.1", "host.fqdn", "::1", "", "192.168.32.0/24",
-# "fe80::100/10", "42540766412265424405338506004571095040/64", true]}, "changed": false}
-#
-# TASK [debug] ********************************************************************************************************
+    # ipwrap() did not filter out non-IP address values, which is usually what you want, e.g. when
+    # you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
+    # you can chain both filters together.
+- name: Show combined result of ipaddr and ipwrap
+    ansible.builtin.debug:
+    msg: "{{ value | ansible.utils.ipaddr | ansible.utils.ipwrap  }}"
+
+# PLAY [Ipwrap filter plugin to wrap IPv6 addresses in [ ] brackets.] *************************************************
+# TASK [Set value as input list] **************************************************************************************
+# ok: [localhost]
+
+# TASK [Show input] ***************************************************************************************************
 # ok: [localhost] => {
 #     "msg": [
 #         "192.24.2.1",
+#         "host.fqdn",
 #         "::1",
+#         "",
 #         "192.168.32.0/24",
 #         "fe80::100/10",
-#         "2001:db8:32c:faad::/64"
+#         "42540766412265424405338506004571095040/64",
+#         true
 #     ]
 # }
-#
-# TASK [debug] ************************************************************************************************
+
+# TASK [Show ipwrap result] *******************************************************************************************
 # ok: [localhost] => {
 #     "msg": [
 #         "192.24.2.1",
@@ -119,13 +126,11 @@ EXAMPLES = r"""
 #         "192.168.32.0/24",
 #         "[fe80::100]/10",
 #         "[2001:db8:32c:faad::]/64",
-#         "True"
+#         true
 #     ]
 # }
-#
-# TASK [ipwrap() did not filter out non-IP address values, which is usually what you want when for example
-# you are mixing IP addresses with hostnames. If you still want to filter out all non-IP address values,
-# you can chain both filters together.] ***
+
+# TASK [Show combined result of ipaddr and ipwrap] ********************************************************************
 # ok: [localhost] => {
 #     "msg": [
 #         "192.24.2.1",

--- a/plugins/filter/ipwrap.py
+++ b/plugins/filter/ipwrap.py
@@ -84,7 +84,7 @@ EXAMPLES = r"""
       - 42540766412265424405338506004571095040/64
       - true
 - name: Show input
-    ansible.builtin.debug:
+  ansible.builtin.debug:
     msg: "{{ value }}"
 
 - name: Show ipwrap result

--- a/plugins/plugin_utils/base/ipaddr_utils.py
+++ b/plugins/plugin_utils/base/ipaddr_utils.py
@@ -493,12 +493,6 @@ def ipaddr(value, query="", version=False, alias="ipaddr"):
         return [item for item in _ret if item]
 
     elif not value or value is True:
-        # TODO: Remove this check in a major version release of collection with porting guide
-        # TODO: and raise exception commented out below
-        display.warning(
-            "The value '%s' is not a valid IP address or network, passing this value to ipaddr filter"
-            " might result in breaking change in future." % value,
-        )
         return False
 
     # Check if value is a number and convert it to an IP address


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The warning about a potential breaking change in the future has been there for 5 years warning that the *intended use of the filter* is not the correct use case. Remove the warning and update the documentation in `ansible.utils.ip_wrap` which specifically suggests using the filter this way.

While on it, also update the documentation so that the commands and example output match.

key line from existing docs:
> If you still want to filter out all non-IP address values, you can chain both filters together

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #240 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ansible.utils.ip_wrap
- base/ip_addr_utils
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
## before
```yaml
[WARNING]: The value '' is not a valid IP address or network, passing this value to ipaddr filter might result in breaking change in future.
[WARNING]: The value 'True' is not a valid IP address or network, passing this value to ipaddr filter might result in breaking change in future.

TASK [Show ipwrap result] ***
ok: [localhost] => {
    "msg": [
        "192.24.2.1",
        "host.fqdn",
        "[::1]",
        "",
        "192.168.32.0/24",
        "[fe80::100]/10",
        "[2001:db8:32c:faad::]/64",
        true
    ]
}
```

## after
```yaml
TASK [Show ipwrap result] ***
ok: [localhost] => {
    "msg": [
        "192.24.2.1",
        "host.fqdn",
        "[::1]",
        "",
        "192.168.32.0/24",
        "[fe80::100]/10",
        "[2001:db8:32c:faad::]/64",
        true
    ]
}
```

*Please* don't do speculative interfaces in the future. Break it - that's fine. Don't break it - also fine.