### PR TITLE
ci: trigger molecule matrix against migrate-integration-to-molecule

### DIFF
--- a/extensions/molecule/MIGRATE_NEXT_STEPS.md
+++ b/extensions/molecule/MIGRATE_NEXT_STEPS.md
@@ -25,3 +25,4 @@ Shared across scenarios:
 6. Commit the scenario tree and delete any hybrid stubs you no longer need.
 
 Agent assist: open `.agents/skills/molecule-migrate-finalize/SKILL.md` (or ask your coding agent to follow that skill).
+# Trigger CI against migrate-integration-to-molecule

--- a/extensions/molecule/MIGRATE_NEXT_STEPS.md
+++ b/extensions/molecule/MIGRATE_NEXT_STEPS.md
@@ -25,4 +25,5 @@ Shared across scenarios:
 6. Commit the scenario tree and delete any hybrid stubs you no longer need.
 
 Agent assist: open `.agents/skills/molecule-migrate-finalize/SKILL.md` (or ask your coding agent to follow that skill).
+
 # Trigger CI against migrate-integration-to-molecule


### PR DESCRIPTION
## Summary
- Nested draft PR whose **base** is `migrate-integration-to-molecule` so `pull_request_target` loads that branch's revised `tests.yml` (not `main`).
- Exercises the new molecule matrix (tox-ansible from `cidrblock/tox-ansible@molecule-test-type`) instead of content-actions integration.

Parent: https://github.com/ansible-collections/ansible.utils/pull/444

## Test plan
- [ ] Matrix Molecule job lists `molecule-*` envs only
- [ ] Molecule jobs install tox-ansible from the fork branch
- [ ] Commands are `molecule test --all --workers 4`