### PR TITLE
ci: split secret-free jobs to pull_request, Sonar label-gated on pull_request_target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 ---
 name: "Release collection"
 on:  # yamllint disable-line rule:truthy
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,27 @@
+---
+name: "SonarCloud 🔍"
+
+concurrency:
+  group: sonar-${{ github.head_ref || github.run_id }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+    types:
+      - labeled
+      - opened
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  sonar:
+    name: SonarCloud
+    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
+    with:
+      python_version: "3.12"
+      test_command: "pytest tests/unit -v --cov-report xml --cov=./ -o 'addopts='"
+    secrets:
+      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,25 +8,17 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  sonar:
-    name: SonarCloud
-    uses: ansible/ansible-content-actions/.github/workflows/sonarcloud.yaml@main
-    with:
-      python_version: "3.12"
-      test_command: "pytest tests/unit -v --cov-report xml --cov=./ -o 'addopts='"
-    secrets:
-      SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
 
   changelog:
     uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
 
   ansible-lint:
     uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@main
@@ -65,7 +57,6 @@ jobs:
       - unit-galaxy
       - ansible-lint
       - integration
-      - sonar
       - report-status
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +68,5 @@ jobs:
           '${{ needs.sanity.result }}',
           '${{ needs.unit-galaxy.result }}',
           '${{ needs.ansible-lint.result }}',
-          '${{ needs.sonar.result }}',
           '${{ needs.report-status.result }}'
           ])"

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - ci - Run secret-free test jobs on pull_request and move SonarCloud to a
+    label-gated pull_request_target workflow.

--- a/changelogs/fragments/disable_auto_release_workflow.yaml
+++ b/changelogs/fragments/disable_auto_release_workflow.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - ci - Disable automatic release workflow on GitHub release publish;
+    trigger manually via workflow_dispatch.


### PR DESCRIPTION
## Summary

- `tests.yml`: switch secret-free jobs (lint, changelog, sanity, unit, build-import) to `pull_request`
- `sonarcloud.yml`: new workflow on `pull_request_target` with `safe to test` label gating (via reusable workflow)
- `release.yml`: replace `release: published` with `workflow_dispatch` (matches ansible-collections/ansible.netcommon#796)
- Matches ansible-collections/cisco.ios#1357 (CI split) + #796 (release)

## Test plan

- [ ] `pull_request` jobs run on this PR
- [ ] Sonar runs on push to main after merge; on PRs requires `safe to test`
- [ ] Release workflow is manual-only (`workflow_dispatch`)