### PR TITLE
Prep_release: Utils Minor release 6.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Ansible Utils Collection Release Notes
 
 .. contents:: Topics
 
+v6.1.0
+======
+
+Minor Changes
+-------------
+
+- remove warning message about potential instability of ipaddr (it has been stable for years)
+
 v6.0.3
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -548,3 +548,15 @@ releases:
       - onboard-codecov.yml
       - update_fact_bracket.yaml
     release_date: "2026-06-12"
+  6.1.0:
+    changes:
+      minor_changes:
+        - remove warning message about potential instability of ipaddr (it has been
+          stable for years)
+    fragments:
+      - ci_pull_request_trigger.yaml
+      - disable_auto_release_workflow.yaml
+      - fix_pytest_mark_error.yml
+      - remove-ipaddr-warning-message-update-docs.yml
+      - tox_skip_cleanup.yml
+    release_date: "2026-07-20"

--- a/changelogs/fragments/add_stale_closure_workflow.yml
+++ b/changelogs/fragments/add_stale_closure_workflow.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - adds a workflow in .github to close stale issues & PRs

--- a/changelogs/fragments/ci_pull_request_trigger.yaml
+++ b/changelogs/fragments/ci_pull_request_trigger.yaml
@@ -1,4 +1,0 @@
----
-trivial:
-  - ci - Run secret-free test jobs on pull_request and move SonarCloud to a
-    label-gated pull_request_target workflow.

--- a/changelogs/fragments/disable_auto_release_workflow.yaml
+++ b/changelogs/fragments/disable_auto_release_workflow.yaml
@@ -1,4 +1,0 @@
----
-trivial:
-  - ci - Disable automatic release workflow on GitHub release publish;
-    trigger manually via workflow_dispatch.

--- a/changelogs/fragments/fix_pytest_mark_error.yml
+++ b/changelogs/fragments/fix_pytest_mark_error.yml
@@ -1,9 +1,0 @@
----
-trivial:
-  - Remove dependency on ``pytest-ansible-network-integration`` (and its transitive
-    dependencies ``cmlutils`` and ``libtmux``) by replacing the ``ansible-navigator``-based
-    integration test runner with a plain ``ansible-playbook`` runner. Each integration
-    target is now executed as an Ansible role via a generated playbook, which correctly
-    loads ``vars/`` and sets ``role_path`` without requiring network device infrastructure.
-  - Removed ``pexpect``, ``ipaddress`` (Python 2 backport), and the now-redundant
-    ``tests/integration/requirements.txt`` used by ``ansible-test integration``.

--- a/changelogs/fragments/onboard-codecov.yml
+++ b/changelogs/fragments/onboard-codecov.yml
@@ -1,2 +1,0 @@
-trivial:
-  - added codecoverage.yml to github actions workflow

--- a/changelogs/fragments/remove-ipaddr-warning-message-update-docs.yml
+++ b/changelogs/fragments/remove-ipaddr-warning-message-update-docs.yml
@@ -1,5 +1,0 @@
----
-minor_changes:
-  - remove warning message about potential instability of ipaddr (it has been stable for years)
-trivial:
-  - update ipwrap docs

--- a/changelogs/fragments/tox_skip_cleanup.yml
+++ b/changelogs/fragments/tox_skip_cleanup.yml
@@ -1,4 +1,0 @@
----
-trivial:
-  - removed the skip section within tox-ansible.ini as they were
-    cleaned up from ansible/tox-ansible.

--- a/changelogs/fragments/update_fact_bracket.yaml
+++ b/changelogs/fragments/update_fact_bracket.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - Fix update_fact to update a fact where a key in the referenced path contains a bracket.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,4 +19,4 @@ tags:
   - data
   - validation
   - utils
-version: 6.0.3
+version: 6.1.0


### PR DESCRIPTION
## Summary
- Bump `galaxy.yml` version to **6.1.0** (minor).
- Generate changelog from pending fragments.
- Clean up leftover fragment files that were already consumed in the 6.0.3 release metadata but never deleted from the tree.

## Changelog highlights
- **Minor changes:** Remove the long-standing ipaddr instability warning; docs updated to match `ipwrap` behaviour (#441).
- **Trivial (CI/test):** pull_request CI split, manual release workflow, tox skip cleanup, pytest/integration runner cleanup.

## Test plan
- [ ] Confirm fragments directory only has `.keep`
- [ ] CI green on this PR
- [ ] After merge: tag `v6.1.0` and run **Release collection** (`workflow_dispatch`)